### PR TITLE
feat: 로그인 한 유저의 방인지 아닌지에 따라 저장하기 버튼 정리 + CI.yml 추가

### DIFF
--- a/.github/workflows/wheretoput_CI.yml
+++ b/.github/workflows/wheretoput_CI.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["dev"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.*
+          cache: npm
+          cache-dependency-path: |
+            next/package-lock.json
+            socket/package-lock.json
+
+      # --- Next.js(Web) ---
+      - name: Install deps (next)
+        run: npm ci
+        working-directory: next/
+			# 소스 코드에 있는 잠재적인 오류, 버그, 스타일 문제를 찾아내는 정적 코드 분석 도구
+      - name: Lint (next)
+        run: npm run lint --if-present
+        working-directory: next/
+
+      - name: Test (next)
+        run: npm test --if-present -- --ci
+        working-directory: next/
+
+      - name: Build (next)
+        run: npm run build
+        working-directory: next/
+
+      # --- NestJS(Socket) ---
+      - name: Install deps (socket)
+        run: npm ci
+        working-directory: socket/
+
+      - name: Lint (socket)
+        run: npm run lint --if-present # 린트 실패해도 계속 진행 # || true 지우면 정상 테스트
+        working-directory: socket/
+
+      - name: Test (socket)
+        run: npm test --if-present -- --ci
+        working-directory: socket/
+
+      - name: Build (socket)
+        run: npm run build
+        working-directory: socket/
+
+  docker-build-check:
+    runs-on: ubuntu-latest
+    needs: quality
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+  
+      # Next.js (web)
+      - name: Build web image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./next
+          file: ./next/Dockerfile.dev   # 개발용이면 dev Dockerfile 지정 가능
+          push: false
+          tags: next:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+  
+      # NestJS (socket)
+      - name: Build api image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./socket
+          file: ./socket/Dockerfile.dev
+          push: false
+          tags: socket:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/next/app/api/rooms/user/route.ts
+++ b/next/app/api/rooms/user/route.ts
@@ -46,8 +46,8 @@ export async function GET(req: NextRequest) {
         const searchParmas = url.searchParams;
         const userId = searchParmas.get('userId');
         const roomId = searchParmas.get('roomId');
-
-        const result = prisma.rooms.findUnique({
+        
+        const result = await prisma.rooms.findUnique({
             where: {
                 user_id: userId || undefined,
                 room_id: roomId || undefined,

--- a/next/app/sim/components/DraggableModel.jsx
+++ b/next/app/sim/components/DraggableModel.jsx
@@ -26,7 +26,7 @@ export function DraggableModel({
       return [1, 1, 1];
     }
   })();
-  console.log(texturePath, isCityKit);
+  // console.log(texturePath, isCityKit);
   const meshRef = useRef();
 
   // Zustand 스토어 사용
@@ -72,7 +72,7 @@ export function DraggableModel({
   // 모델 설정 (그림자, 클릭 이벤트, 텍스처)
   useEffect(() => {
     if (scene && meshRef.current) {
-      console.log(`Setting up model ${modelId} with scale:`, safeScale);
+      // console.log(`Setting up model ${modelId} with scale:`, safeScale);
       
       meshRef.current.traverse((child) => {
         if (child.isMesh) {

--- a/next/app/sim/store/useStore.js
+++ b/next/app/sim/store/useStore.js
@@ -27,6 +27,29 @@ export const useStore = create(
     hoveringModelId: null,
     scaleValue: 1,
 
+    // 방에 접근한 유저가 오너인지 확인
+    isOwnUserRoom: false,
+
+    // 액션으로 분리
+    checkUserRoom: async (roomId, userId) => {
+      try {
+        const response = await fetch(`/api/rooms/user?roomId=${roomId}&userId=${userId}`);
+        if (!response.ok) throw new Error('Network response was not ok');
+        
+        const result = await response.json();
+        if (result) {
+          set({ isOwnUserRoom: true});
+        } else {
+          set({ isOwnUserRoom: false});
+        }
+
+        return result ? true : false;
+      } catch (error) {
+        console.error('FETCH ERROR:', error);
+        set({ isOwnUserRoom: false });
+      }
+    },
+
     // 모델 액션들
     addModel: (model) =>
       set((state) => {

--- a/next/components/sim/SimSideView.tsx
+++ b/next/components/sim/SimSideView.tsx
@@ -1,54 +1,22 @@
 'use client';// 클라이언트 컴포넌트라는 것을 명시 // 이거 안하면 렌더링 안됨
 
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import SideTitle from '@/components/sim/side/SideTitle';
 import SideSearch from '@/components/sim/side/SideSearch';
 import SideCategories from '@/components/sim/side/SideCategories';
 import SideItems from '@/components/sim/side/SideItems';
 import type { furnitures as Furniture } from '@prisma/client';
-import { useSession } from "next-auth/react";
 
 const SimSideView: React.FC<string> = (roomId) => {
   const [collapsed, setCollapsed] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState<string>();
   const [searchResults, setSearchResults] = useState<Furniture[]>([]); // 검색 결과 상태 추가
-  const [isOwnUserRoom, setIsOwnUserRoom] = useState(false);
   const [totalPrice, setTotalPrice] = useState(0);
-  const { data: session, status } = useSession();
-
-  useEffect(() => {
-    const checkOwnRoomOfUser = async () => {
-      
-      if (status === "loading") return;
-      if (!session?.user) return;
-      if (session?.user?.name && session?.user?.id && session?.user?.image) {
-        try {
-          const response = await fetch(`/api/rooms/user?roomId=${roomId}&userId=${session.user.id}`)
-
-          if (!response.ok) {
-            throw new Error('Network response was not ok');
-          }
-
-          const result = await response.json();
-          if (result) {
-            setIsOwnUserRoom(true);
-          } else {
-            setIsOwnUserRoom(false);
-          }
-        } catch (error) {
-          console.error('FETCH ERROR:', error)
-        } 
-      }
-    }
-    console.log(isOwnUserRoom);
-    checkOwnRoomOfUser();
-  }, []);
 
   const handleCategorySelect = (category: string) => {
     setSearchResults([]);
     setSelectedCategory(category);
-    console.log("totalPrice: ",totalPrice);
   }
 
   const handleSearchResults = (results: Furniture[]) => {

--- a/next/components/sim/side/SideTitle.tsx
+++ b/next/components/sim/side/SideTitle.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/roomService";
 import { useRouter } from "next/navigation";
 import { saveRoom } from "@/lib/api/saveRoom";
+import { useSession } from "next-auth/react";
 
 // React 컴포넌트는 반드시 props 객체 하나만 받아야 하기 때문에 interface로 정의
 interface SideTitleProps {
@@ -37,11 +38,14 @@ const SideTitle = ({ collapsed, setCollapsed }: SideTitleProps) => {
     currentRoomId,
     loadedModels,
     setShouldCapture,
+    checkUserRoom, 
   } = useStore();
 
   // 뒤로 가기 버튼
   const router = useRouter()
   const [saveMessage, setSaveMessage] = useState("");
+
+  const { data: session } = useSession();
 
   // 컴포넌트 마운트 시 또는 roomId 변경 시 방 정보 가져오기
   useEffect(() => {
@@ -100,8 +104,12 @@ const SideTitle = ({ collapsed, setCollapsed }: SideTitleProps) => {
 
   // 방 나가기
   const handleOutofRoomClick = async () => {
-    await handleSaveRoom();
-    console.log("방 저장 완료!");
+    const isOwnUserRoom = await checkUserRoom(currentRoomId, session?.user?.id);
+    
+    if (isOwnUserRoom) {
+      await handleSaveRoom();
+      console.log("방 저장 완료!");
+    }
     router.back();
   };
 

--- a/next/lib/api/fetchFurnitures.ts
+++ b/next/lib/api/fetchFurnitures.ts
@@ -57,7 +57,6 @@ export async function fetchFurnitures({
             setTotalItems(data.pagination.totalItems);
             setTotalPages(data.pagination.totalPages);
         }
-        console.log(`data check : ${data}`);
 
     } catch (err) {
         console.error('Failed to fetch items:', err);


### PR DESCRIPTION
<img width="1417" height="655" alt="Screenshot 2025-09-02 at 2 33 47 PM" src="https://github.com/user-attachments/assets/472ae667-8f85-468c-ab77-0cc6807e4d73" />

<img width="1232" height="690" alt="Screenshot 2025-09-02 at 2 34 01 PM" src="https://github.com/user-attachments/assets/54e89571-1f39-470a-838d-8a7d346fc8b3" />

### 로그인 유저의 방
<img width="1416" height="680" alt="Screenshot 2025-09-02 at 2 34 09 PM" src="https://github.com/user-attachments/assets/bee56775-f763-4cac-acb9-c4fd2192f182" />

### 로그인 유저가 아닌 방
<img width="1420" height="691" alt="Screenshot 2025-09-02 at 2 34 22 PM" src="https://github.com/user-attachments/assets/c0436084-3956-4190-a7ec-d4a48046b9a1" />


---

### wheretoput_CI.yml

```yml
name: CI

on:
  pull_request:
    branches: ["dev"]
```

### dev에 푸쉬할 때만 트리거 발동



