### PR TITLE
동시성

### DIFF
--- a/next/app/api/rooms/[id]/collaboration/route.ts
+++ b/next/app/api/rooms/[id]/collaboration/route.ts
@@ -1,0 +1,154 @@
+
+/**
+ * @swagger
+ * /api/rooms/{id}/collaboration:
+ *   get:
+ *     tags:
+ *       - rooms
+ *     summary: 방 협업 모드 상태 확인
+ *     description: 특정 방의 현재 협업 모드 상태를 조회합니다.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 방 ID
+ *     responses:
+ *       200:
+ *         description: 방 협업 상태 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 collab_on:
+ *                   type: boolean
+ *                   description: 협업 모드 활성화 여부
+ *       404:
+ *         description: 방을 찾을 수 없음
+ *       500:
+ *         description: 서버 내부 오류
+ */
+
+import { prisma } from "@/lib/prisma";
+import type { NextRequest } from "next/server";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: room_id } = await params;
+
+    const room = await prisma.rooms.findUnique({
+      where: { room_id },
+      select: {
+        collab_on: true,
+      },
+    });
+
+    if (!room) {
+      return new Response("방을 찾을 수 없습니다", { status: 404 });
+    }
+
+    return Response.json(room);
+  } catch (error: any) {
+    console.error("방 협업 상태 확인 오류:", error);
+    
+    return new Response("서버 내부 오류", { status: 500 });
+  }
+}
+
+/**
+ * @swagger
+ * /api/rooms/{id}/collaboration:
+ *   patch:
+ *     tags:
+ *       - rooms
+ *     summary: 방 협업 모드 토글
+ *     description: 특정 방의 협업 모드 상태를 업데이트합니다. 방 소유자만 이 설정을 변경할 수 있습니다.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 방 ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - collab_on
+ *             properties:
+ *               collab_on:
+ *                 type: boolean
+ *                 description: 협업 모드를 켤지 끌지 여부
+ *     responses:
+ *       200:
+ *         description: 방 협업 상태 업데이트 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 room_id:
+ *                   type: string
+ *                   format: uuid
+ *                 collab_on:
+ *                   type: boolean
+ *                 updated_at:
+ *                   type: string
+ *                   format: date-time
+ *       400:
+ *         description: 잘못된 요청 내용
+ *       404:
+ *         description: 방을 찾을 수 없음
+ *       500:
+ *         description: 서버 내부 오류
+ */
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: room_id } = await params;
+    const body = await req.json();
+
+    if (typeof body.collab_on !== "boolean") {
+      return new Response("잘못된 요청: collab_on은 boolean 값이어야 합니다", {
+        status: 400,
+      });
+    }
+
+    const { collab_on } = body;
+
+    const updatedRoom = await prisma.rooms.update({
+      where: { room_id },
+      data: {
+        collab_on,
+      },
+      select: {
+        room_id: true,
+        collab_on: true,
+        updated_at: true,
+      },
+    });
+
+    return Response.json(updatedRoom);
+  } catch (error: any) {
+    console.error("방 협업 상태 업데이트 오류:", error);
+
+    if (error.code === "P2025") {
+      return new Response("방을 찾을 수 없습니다", { status: 404 });
+    }
+
+    return new Response("서버 내부 오류", { status: 500 });
+  }
+}

--- a/next/app/sim/[id]/page.tsx
+++ b/next/app/sim/[id]/page.tsx
@@ -4,12 +4,23 @@ import React, { useState, useEffect } from "react";
 import { ModeControlPanel } from "@/components/sim/collaboration/ModeControlPanel.jsx";
 import { SimulatorCore } from "@/components/sim/SimulatorCore";
 import { HistoryProvider } from "@/components/sim/history";
+import { useStore } from "@/components/sim/useStore.js";
+import { getColab } from "@/lib/api/toggleColab";
+import { useRouter } from "next/navigation";
 
 /**
  * 일반 시뮬레이터 페이지 (보기/편집 모드)
  */
 function SimPageContent({ params }: { params: Promise<{ id: string }> }) {
   const [roomId, setRoomId] = useState<string | null>(null);
+  const { setCollaborationMode } = useStore();
+  const router = useRouter();
+
+  // 일반 시뮬레이터 모드 초기화
+  useEffect(() => {
+    // 협업 모드를 false로 설정 (일반 편집 모드)
+    setCollaborationMode(false);
+  }, [setCollaborationMode]);
 
   // URL 파라미터에서 room_id 추출
   useEffect(() => {
@@ -19,12 +30,12 @@ function SimPageContent({ params }: { params: Promise<{ id: string }> }) {
         const currentRoomId = resolvedParams.id;
 
         console.log(`일반 시뮬레이터 초기화: room_id = ${currentRoomId}`);
-        
+
         // /rooms/{id}에서 온 경우 sessionStorage 초기화 (create가 아님을 명시)
-        if (document.referrer && document.referrer.includes('/rooms/')) {
-          sessionStorage.setItem('previousPage', 'rooms');
+        if (document.referrer && document.referrer.includes("/rooms/")) {
+          sessionStorage.setItem("previousPage", "rooms");
         }
-        
+
         setRoomId(currentRoomId);
       } catch (error) {
         console.error("시뮬레이터 초기화 실패:", error);

--- a/next/app/sim/collaboration/[id]/page.tsx
+++ b/next/app/sim/collaboration/[id]/page.tsx
@@ -14,6 +14,23 @@ import { useSession } from "next-auth/react";
 import { getColab, toggleColab } from "@/lib/api/toggleColab";
 import { useRouter } from "next/navigation";
 
+// 가독성 있는 색상 생성 함수
+function generateReadableColor() {
+  const colors = [
+    '#3B82F6', // blue
+    '#EF4444', // red  
+    '#10B981', // green
+    '#F59E0B', // yellow
+    '#8B5CF6', // violet
+    '#EC4899', // pink
+    '#06B6D4', // cyan
+    '#84CC16', // lime
+    '#F97316', // orange
+    '#6366F1', // indigo
+  ];
+  return colors[Math.floor(Math.random() * colors.length)];
+}
+
 function CollaborationPageContent({
   params,
 }: {
@@ -43,7 +60,7 @@ function CollaborationPageContent({
     setCurrentUser({
       id: session?.user.id || `user_${Math.floor(Math.random() * 10000)}`,
       name: session?.user.name || `Guest_${Math.floor(Math.random() * 1000)}`,
-      color: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+      color: generateReadableColor(),
     });
   }, [setViewOnly, setCollaborationMode, setCurrentUser]);
 

--- a/next/app/sim/collaboration/[id]/page.tsx
+++ b/next/app/sim/collaboration/[id]/page.tsx
@@ -3,21 +3,36 @@
 import React, { useState, useEffect } from "react";
 import { useStore } from "@/components/sim/useStore.js";
 import { SimulatorCore } from "@/components/sim/SimulatorCore";
-import { ConnectedUsersList } from "@/components/sim/collaboration/CollaborationIndicators.jsx";
+import {
+  ConnectedUsersList,
+  CollaborationEndButton,
+} from "@/components/sim/collaboration/CollaborationIndicators.jsx";
 import { useCollaboration } from "@/components/sim/collaboration/useCollaboration.js";
 import { HistoryProvider } from "@/components/sim/history";
 import { connectSocket, getSocket } from "@/lib/client/socket";
 import { useSession } from "next-auth/react";
+import { getColab, toggleColab } from "@/lib/api/toggleColab";
+import { useRouter } from "next/navigation";
 
 function CollaborationPageContent({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { setCollaborationMode, setViewOnly, setCurrentUser } = useStore();
+  const {
+    setCollaborationMode,
+    setViewOnly,
+    setCurrentUser,
+    checkUserRoom,
+    saveSimulatorState,
+  } = useStore();
 
   const [roomId, setRoomId] = useState<string | null>(null);
+  const [isAccessChecking, setIsAccessChecking] = useState(true);
+  const [accessDenied, setAccessDenied] = useState(false);
+  const [isOwner, setIsOwner] = useState(false);
   const { data: session } = useSession();
+  const router = useRouter();
 
   // 협업 모드 초기 설정
   useEffect(() => {
@@ -35,89 +50,130 @@ function CollaborationPageContent({
   // 협업 훅 활성화
   const collaboration = useCollaboration(roomId);
 
-  // URL 파라미터에서 room_id 추출
+  // 협업 모드 접근 권한 체크
   useEffect(() => {
-    const initializeCollaboration = async () => {
+    const checkCollaborationAccess = async () => {
       try {
         const resolvedParams = await params;
         const currentRoomId = resolvedParams.id;
 
-        console.log(`협업 모드 시뮬레이터 초기화: room_id = ${currentRoomId}`);
-        setRoomId(currentRoomId);
+        // 1. 방 소유자인지 확인
+        let ownerStatus = false;
+        if (!session?.user.id) {
+          ownerStatus = false;
+        } else {
+          ownerStatus = await checkUserRoom(currentRoomId, session.user.id);
+        }
+
+        setIsOwner(ownerStatus); // 소유자 상태 저장
+
+        if (ownerStatus) {
+          // 방 소유자인 경우: 협업 모드 상태 확인 후 자동으로 켜기
+          const collabResult = await getColab(currentRoomId);
+
+          if (collabResult.success) {
+            if (!collabResult.data.collab_on) {
+              // 협업 모드가 꺼져있으면 켜기
+              const toggleResult = await toggleColab(currentRoomId, true);
+              if (toggleResult.success) {
+                console.log(
+                  "방 주인이므로 협업 모드를 자동으로 활성화했습니다"
+                );
+              } else {
+                console.error("협업 모드 활성화 실패:", toggleResult.error);
+              }
+            }
+            setRoomId(currentRoomId);
+            setIsAccessChecking(false);
+          } else {
+            console.error("협업 상태 확인 실패:", collabResult.error);
+            setAccessDenied(true);
+            setIsAccessChecking(false);
+          }
+        } else {
+          // 일반 사용자인 경우: 협업 모드가 켜져있는지 확인
+          const collabResult = await getColab(currentRoomId);
+
+          if (collabResult.success && collabResult.data.collab_on) {
+            // 협업 모드가 켜져있으면 접근 허용
+            setRoomId(currentRoomId);
+            setIsAccessChecking(false);
+          } else {
+            // 협업 모드가 꺼져있거나 오류 시 접근 거부
+            console.log("협업 모드가 비활성화되어 있습니다");
+            console.log("setAccessDenied(true) 호출");
+            setAccessDenied(true);
+            setIsAccessChecking(false);
+            console.log("상태 업데이트 완료");
+          }
+        }
       } catch (error) {
-        console.error("협업 모드 시뮬레이터 초기화 실패:", error);
+        console.error("협업 모드 접근 권한 체크 실패:", error);
+        setAccessDenied(true);
+        setIsAccessChecking(false);
       }
     };
 
-    initializeCollaboration();
-  }, [params]);
+    if (session !== undefined) {
+      checkCollaborationAccess();
+    }
+  }, [params, session, checkUserRoom]);
 
-  if (!roomId) {
-    return <div>Loading...</div>;
+  // 접근 거부 (우선순위 높게)
+  if (accessDenied) {
+    return (
+      <div className="flex flex-col justify-center items-center h-screen gap-5">
+        <div className="text-2xl font-bold">
+          🚫 협업 모드에 접근할 수 없습니다
+        </div>
+        <div className="text-base text-gray-600">
+          방 소유자가 협업 모드를 활성화해야 접근할 수 있습니다
+        </div>
+        <button
+          onClick={() => router.back()}
+          className="px-5 py-2.5 bg-blue-500 text-white border-none rounded-md cursor-pointer hover:bg-blue-600 transition-colors"
+        >
+          이전 페이지로 돌아가기
+        </button>
+      </div>
+    );
   }
 
-  // socket 통신 테스트 해보던거 아직 정확한 작동 X
-  // useEffect(() => {
-  //   let alive = true;
+  // 통합된 로딩 및 상태 관리
+  if (isAccessChecking || !roomId) {
+    return (
+      <div className="flex justify-center items-center h-screen text-lg">
+        🤝 협업 모드 시뮬레이터 로딩 중...
+      </div>
+    );
+  }
 
-  //   const initSocketAndJoinRoom = async () => {
-  //     try {
-  //       // 1. 토큰 가져오기
-  //       const r = await fetch("/api/chat/token", { cache: "no-store" });
-  //       if (!r.ok) {
-  //         console.error("token status", r.status);
-  //         return;
-  //       }
+  // 협업 종료 핸들러
+  const handleEndCollaboration = async () => {
+    if (!roomId) return;
 
-  //       const data = await r.json();
-  //       const token = data.token;
-  //       if (!alive || !token) return;
-
-  //       // 2. 소켓 연결
-  //       const socket = connectSocket(token);
-
-  //       socket.emit('socketConnect', { roomId });
-
-  //       // 3. 연결 대기
-  //       socket.on('connect', () => {
-  //         console.log('Socket connected, joining room:', roomId);
-  //         socket.emit('joinRoom', { roomId });
-  //       });
-
-  //       // 4. 이벤트 리스너 등록
-  //       socket.on('userJoined', (data) => {
-  //         console.log(`사용자 입장:`, data);
-  //       });
-
-  //       socket.on('furnitureUpdated', (data) => {
-  //         console.log('가구 업데이트:', data);
-  //       });
-
-  //       // 이미 연결되어 있다면 바로 방 입장
-  //       if (socket.connected) {
-  //         socket.emit('joinRoom', { roomId });
-  //       }
-
-  //     } catch (e) {
-  //       console.error("Socket init error:", e);
-  //     }
-  //   };
-
-  //   initSocketAndJoinRoom();
-
-  //   return () => {
-  //     alive = false;
-  //     // 소켓 정리
-  //     const socket = getSocket();
-  //     if (socket) {
-  //       socket.emit('leaveRoom', { roomId });
-  //       socket.off('userJoined');
-  //       socket.off('furnitureUpdated');
-  //       socket.off('connect');
-  //       socket.disconnect();
-  //     }
-  //   };
-  // }, [roomId]);
+    if (
+      confirm(
+        "협업 모드를 종료하시겠습니까? 종료 시 현재 집의 상태가 저장됩니다. 종료 시 함께 작업 중인 사용자 모두 퇴장됩니다."
+      )
+    ) {
+      try {
+        const result = await toggleColab(roomId, false);
+        if (result.success) {
+          collaboration.broadcastCollaborationEnd();
+          await saveSimulatorState(); // 종료 전 DB에 저장
+          console.log("협업 모드를 종료했습니다");
+          router.push(`/sim/${roomId}`);
+        } else {
+          console.error("협업 모드 종료 실패:", result.error);
+          alert("협업 모드 종료에 실패했습니다");
+        }
+      } catch (error) {
+        console.error("협업 종료 중 오류:", error);
+        alert("협업 모드 종료 중 오류가 발생했습니다");
+      }
+    }
+  };
 
   return (
     <SimulatorCore
@@ -128,6 +184,12 @@ function CollaborationPageContent({
       additionalUI={
         <>
           <ConnectedUsersList />
+          {/* 방 소유자에게만 협업 종료 버튼 표시 */}
+          {isOwner && (
+            <CollaborationEndButton
+              onEndCollaboration={handleEndCollaboration}
+            />
+          )}
         </>
       }
       loadingMessage="협업 모드 로딩 중..."

--- a/next/components/sim/collaboration/CollaborationIndicators.jsx
+++ b/next/components/sim/collaboration/CollaborationIndicators.jsx
@@ -93,6 +93,21 @@ export function ModelTooltip({ modelId, position, boundingBox }) {
   );
 }
 
+// 협업 종료 버튼 컴포넌트 (방 소유자에게만 표시)
+export function CollaborationEndButton({ onEndCollaboration }) {
+  return (
+    <div className="fixed top-16 right-4 z-50">
+      <button
+        onClick={onEndCollaboration}
+        className="bg-gradient-to-r from-red-500 to-red-600 text-white px-3 py-2 rounded-lg font-medium hover:from-red-600 hover:to-red-700 hover:scale-105 transition-all shadow-lg"
+        title="협업 모드를 종료하고 개인 편집 모드로 돌아갑니다"
+      >
+        협업 종료
+      </button>
+    </div>
+  );
+}
+
 // 연결된 사용자 목록을 UI 상단에 표시
 export function ConnectedUsersList() {
   const { connectedUsers, collaborationMode, isConnected } = useStore();
@@ -112,40 +127,10 @@ export function ConnectedUsersList() {
     >
       {/* 연결된 사용자 목록 */}
       {connectedUsers.size > 0 ? (
-        <div
-          style={{
-            background: "rgba(255, 255, 255, 0.95)",
-            backdropFilter: "blur(10px)",
-            borderRadius: "12px",
-            padding: "8px 12px",
-            boxShadow: "0 4px 12px rgba(0, 0, 0, 0.15)",
-            border: "1px solid rgba(255, 255, 255, 0.2)",
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "8px",
-              marginBottom: "6px",
-            }}
-          >
-            <div
-              style={{
-                width: "8px",
-                height: "8px",
-                borderRadius: "50%",
-                background: "#10b981",
-                animation: "pulse 2s infinite",
-              }}
-            ></div>
-            <span
-              style={{
-                fontSize: "12px",
-                fontWeight: "600",
-                color: "#374151",
-              }}
-            >
+        <div className="bg-white/95 backdrop-blur-sm rounded-xl p-3 shadow-lg border border-white/20">
+          <div className="flex items-center gap-2 mb-1.5">
+            <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></div>
+            <span className="text-xs font-semibold text-gray-700">
               협업 중 • {connectedUsers.size}명
             </span>
           </div>

--- a/next/components/sim/collaboration/useCollaboration.js
+++ b/next/components/sim/collaboration/useCollaboration.js
@@ -112,12 +112,16 @@ export function useCollaboration(roomId) {
 
       if (data.userId === currentUser.id && !isManualDisconnect.current) {
         // 협업 종료로 인한 퇴장인지 일반 퇴장인지 구분
-        const message =
-          data.reason === "collaboration-ended"
-            ? "협업 모드가 종료되어 방에서 나갔습니다."
-            : "비활성 상태로 인해 방에서 퇴장되었습니다.";
-        alert(message);
-        router.push(roomId ? `/sim/${roomId}` : `/`);
+        if (data.reason === "collaboration-ended") {
+          alert("방 소유자가 협업 모드를 종료하여 방에서 나갔습니다.");
+          router.push(roomId ? `/sim/${roomId}` : `/`);
+        } else if (data.reason === "time-out") {
+          alert("비활성 상태로 인해 방에서 퇴장되었습니다.");
+          router.push(roomId ? `/sim/${roomId}` : `/`);
+        } else if (data.reason === "duplicate-connection") {
+          alert("동일한 계정으로 다른 탭에서 접속하여 현재 연결이 해제되었습니다.");
+          router.push(roomId ? `/sim/${roomId}` : `/`);
+        }
       } else {
         // 사용자 정보 제거
         removeConnectedUser(data.userId);
@@ -196,6 +200,8 @@ export function useCollaboration(roomId) {
         console.log(
           `📋 기존 사용자 확인: ${data.userData.name}님이 이미 접속해 있습니다`
         );
+      } else {
+        console.log(`🔄 자신의 정보는 무시: ${data.userData.name}`);
       }
     });
 

--- a/next/components/sim/mainsim/ControlPanel.jsx
+++ b/next/components/sim/mainsim/ControlPanel.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { useStore } from "@/components/sim/useStore";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import { getColab } from "@/lib/api/toggleColab";
 
 const handleSave = async () => {
   if (!currentRoomId) {
@@ -48,6 +49,9 @@ export function ControlPanel({ isPopup = false }) {
     loadSimulatorState,
     checkUserRoom,
     isOwnUserRoom,
+    collaborationMode,
+    checkCollabMode,
+    isCollabModeActive,
   } = useStore();
 
   useEffect(() => {
@@ -59,6 +63,13 @@ export function ControlPanel({ isPopup = false }) {
     };
     useCheckUserRoom();
   }, [isOwnUserRoom, currentRoomId]);
+
+  // 방의 협업 모드 상태 확인
+  useEffect(() => {
+    if (currentRoomId) {
+      checkCollabMode(currentRoomId);
+    }
+  }, [currentRoomId, checkCollabMode]);
 
   // GLB 파일 업로드 처리
   const handleFileUpload = (event) => {
@@ -128,11 +139,12 @@ export function ControlPanel({ isPopup = false }) {
   };
 
   return (
-    <div className={`
+    <div
+      className={`
       bg-black bg-opacity-70 p-4 rounded text-white text-xs w-[250px]
-      ${isPopup ? 'static' : 'absolute top-2.5 right-2.5 z-[100]'}
-    `}>
-     
+      ${isPopup ? "static" : "absolute top-2.5 right-2.5 z-[100]"}
+    `}
+    >
       {/* 벽 스케일 설정 */}
       <div className="mb-2.5">
         <label className="text-white">벽 크기 조정:</label>
@@ -161,32 +173,48 @@ export function ControlPanel({ isPopup = false }) {
       <div className="mb-2.5">
         <button
           onClick={handleSave}
-          disabled={!isOwnUserRoom || !currentRoomId}
+          disabled={
+            !isOwnUserRoom ||
+            !currentRoomId ||
+            (isCollabModeActive && !collaborationMode)
+          }
           className={`
             w-full px-4 py-2.5 text-white border-none rounded text-sm mb-1.5
-            ${currentRoomId
-              ? isSaving
-                ? "bg-gray-500 cursor-not-allowed"
-                : isOwnUserRoom
-                ? "bg-blue-500 hover:bg-blue-600 cursor-pointer"
-                : "bg-gray-500 cursor-not-allowed"
-              : "bg-gray-600 cursor-not-allowed"
+            ${
+              currentRoomId
+                ? isSaving
+                  ? "bg-gray-500 cursor-not-allowed"
+                  : isCollabModeActive && !collaborationMode
+                  ? "bg-gray-500 cursor-not-allowed"
+                  : isOwnUserRoom
+                  ? "bg-blue-500 hover:bg-blue-600 cursor-pointer"
+                  : "bg-gray-500 cursor-not-allowed"
+                : "bg-gray-600 cursor-not-allowed"
             }
           `}
+          title={
+            isCollabModeActive && !collaborationMode
+              ? "협업 모드에서 저장해주세요."
+              : ""
+          }
         >
           {isSaving
             ? "저장 중..."
+            : isCollabModeActive && !collaborationMode
+            ? "협업 모드에서 저장해주세요."
             : isOwnUserRoom
             ? `방 상태 저장 (${loadedModels.length}개)`
-            : `가구 개수 (${loadedModels.length}개)`}
+            : `복제 후 저장해주세요.`}
         </button>
 
         {/* 저장 상태 메시지 */}
         {saveMessage && (
-          <div className={`
+          <div
+            className={`
             text-sm text-center mb-1.5
             ${saveMessage.includes("실패") ? "text-red-400" : "text-green-500"}
-          `}>
+          `}
+          >
             {saveMessage}
           </div>
         )}
@@ -206,11 +234,12 @@ export function ControlPanel({ isPopup = false }) {
           disabled={!currentRoomId}
           className={`
             w-full px-4 py-2.5 text-white border-none rounded text-sm mb-1.5
-            ${currentRoomId
-              ? isCloning
-                ? "bg-gray-500 cursor-not-allowed"
-                : "bg-green-500 hover:bg-green-600 cursor-pointer"
-              : "bg-gray-600 cursor-not-allowed"
+            ${
+              currentRoomId
+                ? isCloning
+                  ? "bg-gray-500 cursor-not-allowed"
+                  : "bg-green-500 hover:bg-green-600 cursor-pointer"
+                : "bg-gray-600 cursor-not-allowed"
             }
           `}
         >

--- a/next/lib/api/toggleColab.ts
+++ b/next/lib/api/toggleColab.ts
@@ -1,0 +1,66 @@
+
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+
+type ToggleResult = {
+  success: boolean;
+  data?: any;
+  error?: string;
+};
+
+// GET  /api/rooms/{id}/collaboration: 협업 모드 여부 확인
+export async function getColab(room_id: string): Promise<ToggleResult> {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/api/rooms/${room_id}/collaboration`,
+      {
+        method: "GET",
+        cache: "no-store",
+      }
+    );
+    if (response.ok) {
+      const data = await response.json();
+      return { success: true, data };
+    }
+    const error = await response.text();
+    return { success: false, error };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+// PATCH  /api/rooms/{id}/collaboration: 협업 모드 토글
+export async function toggleColab(
+  room_id: string,
+  collab_on: boolean
+): Promise<ToggleResult> {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/api/rooms/${room_id}/collaboration`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ collab_on }),
+        cache: "no-store",
+      }
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      return { success: true, data };
+    }
+
+    const error = await response.text();
+    return { success: false, error };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/next/prisma/schema.prisma
+++ b/next/prisma/schema.prisma
@@ -27,14 +27,15 @@ model chat_messages {
 }
 
 model chat_participants {
-  participant_id String     @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  chat_room_id   String     @db.Uuid
-  user_id        String
-  joined_at      DateTime?  @default(now()) @db.Timestamp(6)
-  last_read_at   DateTime?  @db.Timestamp(6)
-  is_admin       Boolean?   @default(false)
-  chat_rooms     chat_rooms @relation(fields: [chat_room_id], references: [chat_room_id], onDelete: Cascade, onUpdate: NoAction)
-  user           User       @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  participant_id   String     @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  chat_room_id     String     @db.Uuid
+  user_id          String
+  joined_at        DateTime?  @default(now()) @db.Timestamp(6)
+  last_read_at     DateTime?  @db.Timestamp(6)
+  is_admin         Boolean?   @default(false)
+  custom_room_name String?    @db.VarChar(100)
+  chat_rooms       chat_rooms @relation(fields: [chat_room_id], references: [chat_room_id], onDelete: Cascade, onUpdate: NoAction)
+  user             User       @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@unique([chat_room_id, user_id])
   @@index([chat_room_id], map: "idx_chat_participants_room")
@@ -169,6 +170,7 @@ model rooms {
   created_at    DateTime?       @default(now()) @db.Timestamp(6)
   updated_at    DateTime?       @default(now()) @db.Timestamp(6)
   root_room_id  String?         @db.Uuid
+  collab_on     Boolean?        @default(false)
   room_comments room_comments[]
   room_likes    room_likes[]
   room_objects  room_objects[]
@@ -211,6 +213,7 @@ model User {
   sessions          Session[]
   following         follows[]           @relation("follows_follower")
   followers         follows[]           @relation("follows_following")
+  user_achievements user_achievements[]
   chat_messages     chat_messages[]
   chat_participants chat_participants[]
   chat_rooms        chat_rooms[]
@@ -258,5 +261,32 @@ model VerificationToken {
   expires    DateTime
 
   @@id([identifier, token])
+  @@schema("auth")
+}
+
+model achievements {
+  id                String              @id @default(dbgenerated("(gen_random_uuid())::text")) @db.VarChar
+  title             String              @db.VarChar
+  description       String?
+  category          String?             @db.VarChar
+  points            Int?                @default(0)
+  icon              String?             @db.VarChar
+  is_active         Boolean?            @default(true)
+  created_at        DateTime?           @default(now()) @db.Timestamptz(6)
+  updated_at        DateTime?           @default(now()) @db.Timestamptz(6)
+  user_achievements user_achievements[]
+
+  @@index([category], map: "idx_achievements_category")
+  @@schema("auth")
+}
+
+model user_achievements {
+  id             String       @id @default(dbgenerated("(gen_random_uuid())::text")) @db.VarChar
+  user_id        String       @db.VarChar
+  achievement_id String       @db.VarChar
+  unlocked_at    DateTime?    @default(now()) @db.Timestamptz(6)
+  achievements   achievements @relation(fields: [achievement_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_user_achievements_achievement_id")
+  User           User         @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_user_achievements_user_id")
+
   @@schema("auth")
 }

--- a/socket/src/collab/collab.gateway.ts
+++ b/socket/src/collab/collab.gateway.ts
@@ -146,7 +146,36 @@ export class CollabGateway {
       userData: data.userData,
       roomId: roomId,
     };
+    
+    // 동일한 userId가 이미 Redis에 있는지 확인
+    let isAlreadyConnected = false;
+    
     if (roomId) {
+      let roomState = await this.redisService.getRoomState(roomId);
+      isAlreadyConnected = roomState?.connectedUsers.has(data.userId) || false;
+      
+      if (isAlreadyConnected) {
+        this.logger.log(`🔄 User ${data.userId} already connected, disconnecting previous connection`);
+        
+        // 기존 연결된 소켓들을 찾아서 강제 퇴장
+        const socketsInRoom = await this.server.in(roomId).fetchSockets();
+        for (const existingSocket of socketsInRoom) {
+          if (existingSocket.data?.userId === data.userId && existingSocket.id !== socket.id) {
+            this.logger.log(`🚪 Disconnecting previous socket ${existingSocket.id} for user ${data.userId}`);
+            
+            // 기존 소켓에 퇴장 이벤트 전송
+            existingSocket.emit('user-left', {
+              userId: data.userId,
+              userData: data.userData,
+              reason: 'duplicate-connection'
+            });
+            
+            // 기존 소켓 연결 해제
+            existingSocket.disconnect(true);
+          }
+        }
+      }
+      
       // Redis에 사용자 정보 저장 (lastActivity 초기값 포함)
       await this.redisService.updateConnectedUser(roomId, data.userId, {
         ...data.userData,
@@ -154,7 +183,7 @@ export class CollabGateway {
       });
 
       // Redis에 방 상태가 없다면 DB에서 전체 로드하여 Redis에 저장
-      let roomState = await this.redisService.getRoomState(roomId);
+      roomState = await this.redisService.getRoomState(roomId);
       if (!roomState || roomState.models.length === 0) {
         this.logger.log(`🔄 Loading room data from DB for room ${roomId}`);
 
@@ -214,12 +243,13 @@ export class CollabGateway {
       }
     }
 
-    // 방의 다른 사용자들에게 브로드캐스트
-    socket.rooms.forEach((room) => {
-      if (room !== socket.id) {
-        socket.to(room).emit('user-join', data);
-      }
-    });
+    // 방의 다른 사용자들에게 브로드캐스트 (이미 연결된 사용자는 제외)
+    if (roomId && !isAlreadyConnected) {
+      socket.to(roomId).emit('user-join', data);
+      this.logger.log(`📤 User-join broadcasted to room ${roomId}`);
+    } else if (isAlreadyConnected) {
+      this.logger.log(`⚠️ Skipping broadcast for already connected user ${data.userId}`);
+    }
   }
 
   // 사용자 퇴장 알림 (수동 퇴장 시에만 사용, 자동 단절은 handleDisconnect에서 처리)
@@ -548,7 +578,8 @@ export class CollabGateway {
             // 다른 사용자들에게 퇴장 알림 브로드캐스트 (userData 포함)
             this.server.to(roomId).emit('user-left', {
               userId,
-              userData: userData || { name: userId }, // fallback으로 userId 사용
+              userData: userData || { name: userId }, // fallback으로 userId 사용,
+              reason: 'time-out', // 시간 종료로 인한 퇴장임을 명시
             });
 
             this.logger.log(


### PR DESCRIPTION
# Redis 사전설정
넥스트, 소켓 양쪽에서  `npm install` 및 `npx prisma generate`

`docker pull redis`

`docker run -d --name redis-server -p 6379:6379 redis:latest`

소켓 폴더 `.env`파일에서  `REDIS_URL="redis://localhost:6379"` 설정



# 협업 방 파기

<img width="277" height="117" alt="image" src="https://github.com/user-attachments/assets/539c6ab1-4179-4d79-8b46-30591d898e1c" />

방장은 항상 위 토글 창에서 <협업> 버튼을 확인할 수 있습니다. 누르면 협업 모드가 활성화됩니다.

다른 사람의 방을 보는 경우, 협업 모드가 켜진 경우만 <협업> 버튼이 활성화됩니다.

누르면 `/sim` => `/sim/collaboration`으로 이동합니다.

협업이 활성화된 상황에서는 일반 모드에서는 저장이 막히며, 협업 모드에서만 저장할 수 있습니다. (물론 저장 권한은 방장에만 있습니다)

협업 여부 확인 위해 `rooms`에 `collab_on` (불린값) 컬럼이 추가됐으므로 ,**넥스트 쪽(`/next`)**에서 `npx prisma generate` 다시 하셔야 합니다

# 협업 진행 중
<img width="1902" height="955" alt="image" src="https://github.com/user-attachments/assets/682cb573-0043-41f5-b2e2-12806699fb6d" />

상대방이 작업 중인 object는 말풍선 위에 뜨고, 선택되지 않습니다.

object 선택 후 아무 동작이 1분 간 없으면 자동으로 lock이 해제됩니다.

# 협업 종료

<img width="933" height="326" alt="image" src="https://github.com/user-attachments/assets/6c91ba1b-f19a-4e9e-846a-d4b15daf32f1" />


방장만 <협업 종료> 버튼으로 협업을 종료할 수 있습니다. 종료 시 다른 참여자는 자동으로 퇴장 됩니다.

<img width="959" height="269" alt="image" src="https://github.com/user-attachments/assets/a790c07f-ab2f-4bc9-8a8d-f305a18a507b" />


방장이 협업을 종료하지 않고 퇴장만 한 경우, 남은 사용자들은 협업을 계속할 수 있습니다.