### PR TITLE
fix: port 재수정 및 CD.yml 수정

### DIFF
--- a/docker-compose.next.yml
+++ b/docker-compose.next.yml
@@ -4,7 +4,7 @@ services:
   next:
     image: ${ECR_REGISTRY}/${ECR_REPO_NEXT}:${IMAGE_TAG}
     ports:
-      - "${EC2_HOST_NEXT:-3000}:3000"
+      - "3000:3000"
     environment:
       - NODE_ENV=production
       - DATABASE_URL=${DATABASE_URL}

--- a/docker-compose.next.yml
+++ b/docker-compose.next.yml
@@ -4,7 +4,7 @@ services:
   next:
     image: ${ECR_REGISTRY}/${ECR_REPO_NEXT}:${IMAGE_TAG}
     ports:
-      - "3000:3000"
+      - "${EC2_HOST_NEXT:-3000}:3000"
     environment:
       - NODE_ENV=production
       - DATABASE_URL=${DATABASE_URL}


### PR DESCRIPTION
## 문제 발생
```yml
drone-scp version: v1.6.14
tar all files into /tmp/DyrwcXjcoN.tar.gz
remote server os type is unix
scp file to server.
2025/09/07 05:11:24 error copy file to dest: https, error message: dial tcp: address tcp///wheretoput.store: unknown port
drone-scp error: error copy file to dest: https, error message: dial tcp: address tcp///wheretoput.store: unknown port
```
drone-scp 이거 때문에 문제가 발생한다고 했다.

우리의 CD.yml 파일은 `drone-scp`가 아니라 `appleboy/scp-action`을 사용하고 있다고 했음.

그래서
```yml
- name: Upload files to NestJS EC2
  uses: appleboy/scp-action@v0.1.7
  with:
    host: ${{ secrets.EC2_HOST_SOCKET }}  # 여기가 문제!
```
- EC2_HOST_SOCKET: 이거를
- EC2_SSH_HOST_SOCKET = 실제 EC2 인스턴스 IP 또는 SSH 호스트명

이렇게 수정 했음.
