### PR TITLE
fix: socket/main.ts app.setGlobalPrefix('api/socket') 추가

### DIFF
--- a/socket/src/main.ts
+++ b/socket/src/main.ts
@@ -13,6 +13,9 @@ async function bootstrap() {
       credentials: true,
     });
 
+    console.log('Setting global prefix...');
+    app.setGlobalPrefix('api/socket');
+
     console.log('Starting server on port 3001...');
     await app.listen(3001, '0.0.0.0');
     console.log('✅ Socket server is running on port 3001');


### PR DESCRIPTION
```typescript
console.log('Setting global prefix...');
    app.setGlobalPrefix('api/socket');
```

추가 for AWS 설정