### PR TITLE
fix: 3D 모델 생성 시 temp 폴더 접근권한 허용

### DIFF
--- a/.github/workflows/wheretoput_CD.yml
+++ b/.github/workflows/wheretoput_CD.yml
@@ -175,6 +175,8 @@ jobs:
             docker system prune -f
             set -e
             cd ${{ secrets.EC2_DEPLOY_PATH }}/socket
+
+            mkdir -p ./temp && chmod 755 ./temp
             
             aws ecr get-login-password --region ${{ env.AWS_REGION }} | \
               docker login --username AWS --password-stdin ${{ env.ECR_REGISTRY }}


### PR DESCRIPTION
현재 문제: 3D 모델 없을때 생성할때 db 이미지 링크를 `/temp`에 저장하는데, 해당 path 접근권한이 없어서 실패

```
[Error: EACCES: permission denied, open '/app/temp/temp_49b250cf-4cee-4bad-a62a-80b670630cc7_1757169888449.png'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/app/temp/temp_49b250cf-4cee-4bad-a62a-80b670630cc7_1757169888449.png'
}
 ⨯ uncaughtException:  [Error: EACCES: permission denied, open '/app/temp/temp_49b250cf-4cee-4bad-a62a-80b670630cc7_1757169888449.png'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/app/temp/temp_49b250cf-4cee-4bad-a62a-80b670630cc7_1757169888449.png'
}
```

이를 해결하기 위해 깃허브액션 파일에 폴더생성/권한추가

```
 # temp 디렉토리 생성 및 권한 설정 (여기에 추가)
 mkdir -p ./temp && chmod 755 ./temp
```