### PR TITLE
corsenable

### DIFF
--- a/socket/src/chat/chat.gateway.ts
+++ b/socket/src/chat/chat.gateway.ts
@@ -23,7 +23,10 @@ type SendPayload = { roomId: string; content: string; tempId?: string };
 
 // @UseGuards(JwtAuthGuard) // 임시 비활성화
 @WebSocketGateway({
-  cors: { origin: [/^http:\/\/localhost:\d+$/], credentials: true },
+  cors: {
+    origin: [/^http:\/\/localhost:\d+$/, 'https://wheretoput.store'],
+    credentials: true,
+  },
   namespace: '/',
 })
 export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {

--- a/socket/src/main.ts
+++ b/socket/src/main.ts
@@ -6,10 +6,13 @@ async function bootstrap() {
   try {
     console.log('Starting NestJS application...');
     const app = await NestFactory.create(AppModule);
-    
+
     console.log('Setting up CORS...');
     app.enableCors({
-      origin: process.env.EC2_HOST_NEXT || '*',
+      origin: [
+        /^http:\/\/localhost:\d+$/,
+        process.env.EC2_HOST_NEXT || 'https://wheretoput.store',
+      ],
       credentials: true,
     });
 


### PR DESCRIPTION
CORS 설정이 원래 `localhost:3000`만 되는 걸로 적용되어 있어서, `https://wheretoput.store`도 허용하게 수정함.

```ts
// chat.gateway.ts
@WebSocketGateway({
  cors: {
    origin: [/^http:\/\/localhost:\d+$/, 'https://wheretoput.store'],
    credentials: true,
  },
  namespace: '/',
})
```

```ts
//collab.gateway.ts
@WebSocketGateway({
  namespace: '/collab',
  cors: {
    origin: [/^http:\/\/localhost:\d+$/, 'https://wheretoput.store'],
    credentials: true,
  },
})
```

```ts
// main.ts
    app.enableCors({
      origin: [
        /^http:\/\/localhost:\d+$/,
        process.env.EC2_HOST_NEXT || 'https://wheretoput.store',
      ],
      credentials: true,
    });
```