### PR TITLE
fix: WASD 씹힘문제해결

### DIFF
--- a/next/components/sim/mainsim/KeyboardControls.jsx
+++ b/next/components/sim/mainsim/KeyboardControls.jsx
@@ -4,14 +4,20 @@ import * as THREE from "three";
 
 export function KeyboardControls({ controlsRef, disabled = false }) {
   const keys = useRef({});
-  const { camera } = useThree();
+  const { camera, invalidate } = useThree();
+  const velocityRef = useRef(new THREE.Vector3());
+  const lastDirectionRef = useRef(new THREE.Vector3());
+  const lastTargetRef = useRef(new THREE.Vector3());
 
   useEffect(() => {
     const handleKeyDown = (e) => {
       keys.current[e.code] = true;
+      // 키 입력 시 velocity 리셋하지 않고 즉시 렌더링 요청
+      invalidate();
     };
     const handleKeyUp = (e) => {
       keys.current[e.code] = false;
+      invalidate();
     };
 
     window.addEventListener("keydown", handleKeyDown);
@@ -21,40 +27,73 @@ export function KeyboardControls({ controlsRef, disabled = false }) {
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("keyup", handleKeyUp);
     };
-  }, [camera, controlsRef]);
+  }, [camera, controlsRef, invalidate]);
 
-  useFrame((_, delta) => {
-    // 키보드 컨트롤이 비활성화된 경우 movement 처리하지 않음
+  useFrame((state, delta) => {
     if (disabled) return;
 
-    const speed = 10;
+    // OrbitControls 타겟 변화 감지 및 velocity 리셋
+    if (controlsRef?.current?.target) {
+      const currentTarget = controlsRef.current.target;
+      if (!lastTargetRef.current.equals(currentTarget)) {
+        // 타겟이 변경되면 velocity 리셋하여 갑작스러운 움직임 방지
+        velocityRef.current.set(0, 0, 0);
+        lastTargetRef.current.copy(currentTarget);
+      }
+    }
+
+    const anyKeyPressed = 
+      keys.current["KeyW"] || keys.current["KeyS"] || 
+      keys.current["KeyA"] || keys.current["KeyD"] ||
+      keys.current["KeyQ"] || keys.current["KeyE"];
+
+    const baseSpeed = 15;
+    const acceleration = 50;
+    const deceleration = 25;
+    const maxSpeed = 20;
 
     const forward = new THREE.Vector3();
     camera.getWorldDirection(forward);
-
-    // W,S키 입력 시 바라보는    방향으로 정확히 이동 : 주석 처리
-    //                      방향의 X,Z 방향만 고려 : 주석 해제 (오늘의 집에선 이걸 사용)
     forward.y = 0;
+    forward.normalize();
 
     const right = new THREE.Vector3();
     right.crossVectors(camera.up, forward).normalize();
 
-    let move = new THREE.Vector3();
+    let inputDirection = new THREE.Vector3();
 
-    if (keys.current["KeyW"]) move.add(forward);
-    if (keys.current["KeyS"]) move.add(forward.clone().negate());
-    if (keys.current["KeyA"]) move.add(right);
-    if (keys.current["KeyD"]) move.add(right.clone().negate());
+    if (keys.current["KeyW"]) inputDirection.add(forward);
+    if (keys.current["KeyS"]) inputDirection.sub(forward);
+    if (keys.current["KeyA"]) inputDirection.add(right);
+    if (keys.current["KeyD"]) inputDirection.sub(right);
 
-    if (keys.current["KeyQ"]) move.add(new THREE.Vector3(0, 1, 0));
-    if (keys.current["KeyE"]) move.add(new THREE.Vector3(0, -1, 0));
+    if (keys.current["KeyQ"]) inputDirection.add(new THREE.Vector3(0, 1, 0));
+    if (keys.current["KeyE"]) inputDirection.add(new THREE.Vector3(0, -1, 0));
 
-    if (move.lengthSq() > 0) {
-      move.normalize().multiplyScalar(speed * delta);
-      camera.position.add(move);
+    if (inputDirection.lengthSq() > 0) {
+      inputDirection.normalize();
+      
+      const targetVelocity = inputDirection.clone().multiplyScalar(baseSpeed);
+      const velocityDiff = targetVelocity.clone().sub(velocityRef.current);
+      
+      velocityRef.current.add(velocityDiff.multiplyScalar(acceleration * delta));
+      
+      if (velocityRef.current.length() > maxSpeed) {
+        velocityRef.current.normalize().multiplyScalar(maxSpeed);
+      }
+      
+      lastDirectionRef.current.copy(inputDirection);
+    } else {
+      velocityRef.current.multiplyScalar(Math.max(0, 1 - deceleration * delta));
+    }
+
+    if (velocityRef.current.lengthSq() > 0.001) {
+      const movement = velocityRef.current.clone().multiplyScalar(delta);
+      camera.position.add(movement);
 
       if (controlsRef?.current) {
-        controlsRef.current.target.add(move);
+        controlsRef.current.target.add(movement);
+        controlsRef.current.update();
       }
     }
   });


### PR DESCRIPTION
현재 canvas는 frameloop="demand" 모드에서 동작합니다.
매 프레임 렌더링을 하지 않게 설정하는 역할입니다. 이거 안 켜면 이륙합니다.
덕분에 속도는 빨라지지만 wasd로 컨트롤할 때 많이 씹힙니다.
그래서 wasd 할 때는 `invalidate`로 즉시 렌더링되게 고쳤습니다.

그 외 클로드가 추천을 해서 velocity 계산하는 것도 있던데 제가 물포자라서 설명은 안하겠습니다. 머 가속도 줘서 좀더 부드럽게 움직이게하는거라고하네요.

```
  useEffect(() => {
    const handleKeyDown = (e) => {
      keys.current[e.code] = true;
      // 키 입력 시 velocity 리셋하지 않고 즉시 렌더링 요청
      invalidate();
    };
    const handleKeyUp = (e) => {
      keys.current[e.code] = false;
      invalidate();
    };
```