### PR TITLE
fix: 채팅방 읽음 처리 문제 해결 + 카테고리 전체 추가

### DIFF
--- a/next/app/api/sim/furnitures/route.ts
+++ b/next/app/api/sim/furnitures/route.ts
@@ -70,7 +70,6 @@ import { calculatePagination } from "@/lib/paginagtion";
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    console.log("Search params:", searchParams.toString());
     const page = parseInt(searchParams.get("page") || "1");
     const limit = parseInt(searchParams.get("limit") || "5");
     const categoryParam = searchParams.get("category");
@@ -101,10 +100,8 @@ export async function GET(request: Request) {
     let totalCount: number = 0;
 
     try {
-      if (categoryParam && !isNaN(category)) {
+      if (categoryParam && Number(category) < 99) {
         // 카테고리가 지정된 경우
-        console.log("카테고리 필터링:", category);
-
         [furnitures, totalCount] = await Promise.all([
           prisma.furnitures.findMany({
             where: {
@@ -122,8 +119,6 @@ export async function GET(request: Request) {
         ]);
       } else {
         // 카테고리 지정 안된 경우 - 전체 가구
-        console.log("전체 가구 조회");
-
         [furnitures, totalCount] = await Promise.all([
           prisma.furnitures.findMany({
             take: limit,

--- a/next/components/chat/hooks/useChatMessages.ts
+++ b/next/components/chat/hooks/useChatMessages.ts
@@ -69,7 +69,7 @@ export const useChatMessages = (
               content: m.content,
               message_type: m.message_type ?? (isImageMessage ? "image" : "text"),
               createdAt: m.createdAt ?? m.created_at,
-              status: "read",
+              status: m.status, // ******* 이거 수정 *******
             };
           }
         );
@@ -132,7 +132,7 @@ export const useChatMessages = (
         content: m.content,
         message_type: m.message_type ?? (isImageMessage ? "image" : "text"),
         createdAt: m.createdAt ?? m.created_at,
-        status: "sent",
+        status: m.status,
       };
 
       setMessagesByRoom((prev) => {

--- a/next/components/chat/hooks/useChatRooms.ts
+++ b/next/components/chat/hooks/useChatRooms.ts
@@ -75,19 +75,23 @@ export const useChatRooms = (
           };
 
           // 마지막 메시지가 내가 보낸 메시지라면 강제로 읽음 처리
-          if (
-            result.lastMessageSenderId === currentUserId &&
-            result.lastMessageAt
-          ) {
-            result.last_read_at = result.lastMessageAt;
-          }
+          // console.log("마지막 메시지가 누가 보냈을까?");
+          // console.log("result.lastMessageSenderId", result.lastMessageSenderId);
+          // console.log("currentUserId", currentUserId);
+          // console.log("result.lastMessageAt", result.lastMessageAt);
+          // if (
+          //   result.lastMessageSenderId === currentUserId &&
+          //   result.lastMessageAt
+          // ) {
+          //   result.last_read_at = result.lastMessageAt;
+          // }
 
-          console.log(
-            "lastMessageAt:",
-            result.lastMessageAt,
-            "last_read_at:",
-            result.last_read_at
-          );
+          // console.log(
+          //   "lastMessageAt:",
+          //   result.lastMessageAt,
+          //   "last_read_at:",
+          //   result.last_read_at
+          // );
 
           return result;
         });
@@ -154,13 +158,13 @@ export const useChatRooms = (
             searchIndex: (lastMsg ?? "").toLocaleLowerCase("ko-KR"),
           };
 
-          // 마지막 메시지가 내가 보낸 메시지라면 강제로 읽음 처리
-          if (
-            result.lastMessageSenderId === currentUserId &&
-            result.lastMessageAt
-          ) {
-            result.last_read_at = result.lastMessageAt;
-          }
+          // // 마지막 메시지가 내가 보낸 메시지라면 강제로 읽음 처리
+          // if (
+          //   result.lastMessageSenderId === currentUserId &&
+          //   result.lastMessageAt
+          // ) {
+          //   result.last_read_at = result.lastMessageAt;
+          // }
 
           return result;
         });

--- a/next/components/sim/side/SideCategories.tsx
+++ b/next/components/sim/side/SideCategories.tsx
@@ -21,6 +21,7 @@ const SideCategories: React.FC<SideCategoriesProps> = ({ collapsed, onCategorySe
   // # 10 = Bedroom , 11 = Outdoor
   // # 12 = Home Decor
   const categories: CategoryProps[] = [
+    { id: 99, name: "전체" }, 
     { id: -2, name: "가구" }, 
     { id: 0, name: "의자" }, 
     { id: 1, name: "조명" }, 

--- a/next/components/sim/side/SideItems.tsx
+++ b/next/components/sim/side/SideItems.tsx
@@ -68,22 +68,9 @@ const SideItems: React.FC<SideItemsProps> = ({
   // 페이지나 카테고리 변경 시 데이터 가져오기
   useEffect(() => {
     const handleCategoryChange = async () => {
-      if (selectedCategory === "-1") {
-        const pagination = calculatePagination(currentPage, 5, totalPages);
-        setTotalItems(pagination.totalItems);
-        setTotalPages(pagination.totalPages);
-        const furnitureId = loadedModels.map((item: any) => item.furniture_id);
-        const result = await fetchSelectedFurnitures(furnitureId, roomId, sortOption);
-
-        if (result) {
-          setSelectedItems(result.furnitures);
-          setTotalPrice(result.totalPrice);
-        }
-      } else {
-        fetchItems(currentPage, selectedCategory, sortOption);
-        setSelectedItems([]);
-        setTotalPrice(0);
-      }
+      fetchItems(currentPage, selectedCategory, sortOption);
+      setSelectedItems([]);
+      setTotalPrice(0);
     };
     handleCategoryChange();
   }, [currentPage, selectedCategory, sortOption, fetchItems]);

--- a/next/components/sim/useStore.js
+++ b/next/components/sim/useStore.js
@@ -49,7 +49,7 @@ export const useStore = create(
 
     return {
       // 선택된 카테고리
-      selectedCategory: -2,
+      selectedCategory: 99,
       setSelectedCategory: (categoryId) =>
         set({ selectedCategory: categoryId }),
 


### PR DESCRIPTION
# 아침에 다시 수정

새벽에 처리했던 방식
chat_participants 테이블에 한 방의 id가 2개 있었음.
이 말은 1:1 상대방과 나 모두 participants 하나씩 생성된다. 그러면 각각 last_read_at attribute로 관리되니 굳이 last_read_id가 필요 없었고,

상대방의 last_read_at을 확인해 chat_messages에 이 room_id의 내가 보낸 마지막 시간 보다 더 크다면 `읽음` 아니라면 `보냄`
이렇게 생각하고 비즈니스 로직을 건드려 수정한 후 PR 올려놨는데,

오늘 아침에 어? 왜 안되어있지 하고 다시 수정함.
근데 매우 간단하게 해결됨.

# 전체 카테고리 추가

<img width="488" height="752" alt="Screenshot 2025-09-09 at 11 35 11 AM" src="https://github.com/user-attachments/assets/048def51-c4b1-4811-9b83-ba977670be64" />
