### PR TITLE
fix: 새로운 가구 카테고리 추가 및 크롤링 파일 업데이트

### DIFF
--- a/next/app/crawling.py
+++ b/next/app/crawling.py
@@ -123,6 +123,21 @@ for z in [tables_category_index]:
         driver.find_element(By.XPATH, f'//*[@id="root"]/section/div[1]/div[1]/div/section/aside/div/section/div[{z+1}]').click()
         time.sleep(1) # 카테고리 내 가구 로딩 대기
 
+
+        # 필요시 스크롤 다운
+        # from selenium.webdriver.support.ui import WebDriverWait
+        # from selenium.webdriver.support import expected_conditions as EC
+        # 스크롤 대상 요소 대기 & 획득
+        # scroll_container = WebDriverWait(driver, 10).until(
+        #     EC.presence_of_element_located((
+        #         By.XPATH,
+        #         # aside 패널 ↓ 내부의 리스트 컨테이너 ↓ 그 안의 overflow:auto div
+        #         "//aside[contains(@class,'AsidePanel__Panel')]"
+        #         "//section[contains(@class,'LibraryItemList2__Container')]"
+        #         "//div[contains(@style,'overflow') and contains(@style,'auto')]"
+        #     ))
+        # )
+
         # 이 예제에서는 각 카테고리별로 일부만 가져오도록 범위를 작게 설정 (필요시 range 수정)
         for i in range(1, 11): # 행 (10행까지)
             for j in range(1, 3): # 열 (2열까지)

--- a/next/components/chat/hooks/useChatRooms.ts
+++ b/next/components/chat/hooks/useChatRooms.ts
@@ -155,12 +155,12 @@ export const useChatRooms = (
           };
 
           // // 마지막 메시지가 내가 보낸 메시지라면 강제로 읽음 처리
-          // if (
-          //   result.lastMessageSenderId === currentUserId &&
-          //   result.lastMessageAt
-          // ) {
-          //   result.last_read_at = result.lastMessageAt;
-          // }
+          if (
+            result.lastMessageSenderId === currentUserId &&
+            result.lastMessageAt
+          ) {
+            result.last_read_at = result.lastMessageAt;
+          }
 
           return result;
         });

--- a/next/components/sim/achievement/components/ArchievementToast.tsx
+++ b/next/components/sim/achievement/components/ArchievementToast.tsx
@@ -42,7 +42,7 @@ export function ArchievementToast() {
         {/* 업적 토스트 */}
         {achievementToast && (
             <div className="fixed top-25 left-1/2 transform -translate-x-1/2 z-[200] max-w-sm">
-                <div className="bg-blue-500/80 backdrop-blur-sm text-white p-4 rounded-xl shadow-2xl border border-white/20">
+                <div className="bg-orange-500/80 backdrop-blur-sm text-white p-4 rounded-xl shadow-2xl border border-white/20">
                     <div className="flex items-center gap-3 text-white">
                         <div className="text-2xl drop-shadow-lg">{achievementToast.icon || '🏆'}</div>
                         <div>

--- a/next/components/sim/side/SideCategories.tsx
+++ b/next/components/sim/side/SideCategories.tsx
@@ -29,6 +29,7 @@ const SideCategories: React.FC<SideCategoriesProps> = ({ collapsed, onCategorySe
     { id: 4, name: "데코" }, 
     { id: 5, name: "욕실용품" }, 
     { id: 7, name: "가전·디지털" }, 
+    { id: 9, name: "설치 가구" }, 
     { id: 10, name: "침구류" }, 
 
   ];

--- a/next/components/sim/side/item/ItemSection.tsx
+++ b/next/components/sim/side/item/ItemSection.tsx
@@ -120,6 +120,12 @@ const ItemSection: React.FC<ItemSectionProps> = ({
                                                 {Number(item.count).toLocaleString()}
                                             </span>
                                             )}
+                                            {/* 모델이 있는 것들만 표시 시현 때 딜레이 방지 */}
+                                            {item.model_url && (
+                                                <span className="text-xs font-semibold text-gray-700">
+                                                    ．
+                                                </span>
+                                            )}
                                         </div>
                                     )}
 


### PR DESCRIPTION
## 추가 카테고리 - `설치 가구`

<img width="392" height="692" alt="Screenshot 2025-09-09 at 3 03 20 PM" src="https://github.com/user-attachments/assets/ed9ad97d-a33a-4d84-ab63-76b78d7c2ddb" />

## 크롤링 파일 업데이트

```python
# 필요시 스크롤 다운
# from selenium.webdriver.support.ui import WebDriverWait
# from selenium.webdriver.support import expected_conditions as EC
# 스크롤 대상 요소 대기 & 획득
# scroll_container = WebDriverWait(driver, 10).until(
#     EC.presence_of_element_located((
#         By.XPATH,
#         # aside 패널 ↓ 내부의 리스트 컨테이너 ↓ 그 안의 overflow:auto div
#         "//aside[contains(@class,'AsidePanel__Panel')]"
#         "//section[contains(@class,'LibraryItemList2__Container')]"
#         "//div[contains(@style,'overflow') and contains(@style,'auto')]"
#     ))
# )
```

## 트릭용으로 model_url 있는 것과 없는 것 `.` 으로 구분 처리
<img width="1110" height="727" alt="Screenshot 2025-09-09 at 4 05 13 PM" src="https://github.com/user-attachments/assets/e3a370f5-3bc4-4eb2-9173-778691ed1f13" />
