### PR TITLE
Socketfix

### DIFF
--- a/next/app/sim/collaboration/[id]/page.tsx
+++ b/next/app/sim/collaboration/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useStore } from "@/components/sim/useStore.js";
 import { SimulatorCore } from "@/components/sim/SimulatorCore";
 import {
@@ -63,6 +63,11 @@ function CollaborationPageContent({
   
   const { token } = useChatConnection(true); // 항상 연결
   
+  // 채팅방 업데이트 콜백을 useCallback으로 메모이제이션
+  const handleChatRoomUpdate = useCallback(() => {
+    // 협업 모드에서는 채팅방 목록을 관리하지 않으므로 빈 함수
+  }, []);
+  
   const {
     selectedMessages,
     text,
@@ -74,7 +79,7 @@ function CollaborationPageContent({
     selectedChatId, // 선택된 채팅방 ID
     token,
     session?.user?.id || null,
-    () => {} // updateChatRoom은 빈 함수로
+    handleChatRoomUpdate
   );
 
   // 협업 모드 초기 설정

--- a/next/components/sim/useStore.js
+++ b/next/components/sim/useStore.js
@@ -426,7 +426,7 @@ export const useStore = create(
 
       deselectModel: (shouldBroadcast = true) => {
         const currentSelectedId = get().selectedModelId;
-        set({ selectedModelId: null });
+        set({ selectedModelId: null, snappedWallInfo: null });
         if (shouldBroadcast) {
           get().broadcastWithThrottle(
             "broadcastModelDeselect",

--- a/next/lib/client/socket.ts
+++ b/next/lib/client/socket.ts
@@ -2,17 +2,19 @@ import { io, Socket } from "socket.io-client";
 
 // 네임스페이스별로 소켓 관리
 const sockets = new Map<string, Socket>();
-const connectionStates = new Map<string, { connecting: boolean; lastConnectTime: number }>();
+const connectionStates = new Map<
+  string,
+  { connecting: boolean; lastConnectTime: number }
+>();
 
 export function connectSocket(jwt: string, namespace: string = "/") {
   const serverUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
   const fullUrl = serverUrl + namespace;
 
-  
   // 중복 연결 시도 방지
   const state = connectionStates.get(namespace);
-  if (state?.connecting && (Date.now() - state.lastConnectTime) < 3000) {
-    console.log('🔄 CONNECTION ALREADY IN PROGRESS:', fullUrl);
+  if (state?.connecting && Date.now() - state.lastConnectTime < 3000) {
+    console.log(`🔄 CONNECTION ALREADY IN PROGRESS [${namespace}]:`, fullUrl);
     return sockets.get(namespace) || createNewSocket(jwt, namespace, fullUrl);
   }
 
@@ -20,11 +22,14 @@ export function connectSocket(jwt: string, namespace: string = "/") {
   if (sockets.has(namespace)) {
     const existingSocket = sockets.get(namespace)!;
     if (existingSocket.connected) {
-      console.log("🔄 REUSING EXISTING SOCKET:", fullUrl);
+      console.log(`🔄 REUSING EXISTING SOCKET [${namespace}]:`, fullUrl);
       return existingSocket;
     } else {
       // 연결이 끊어진 소켓은 제거하고 새로 생성
-      console.log('🔄 CLEANING UP DISCONNECTED SOCKET:', fullUrl);
+      console.log(
+        `🔄 CLEANING UP DISCONNECTED SOCKET [${namespace}]:`,
+        fullUrl
+      );
       existingSocket.removeAllListeners();
       existingSocket.disconnect();
       sockets.delete(namespace);
@@ -34,56 +39,86 @@ export function connectSocket(jwt: string, namespace: string = "/") {
   return createNewSocket(jwt, namespace, fullUrl);
 }
 
-function createNewSocket(jwt: string, namespace: string, fullUrl: string): Socket {
+function createNewSocket(
+  jwt: string,
+  namespace: string,
+  fullUrl: string
+): Socket {
   // 연결 상태 업데이트
-  connectionStates.set(namespace, { connecting: true, lastConnectTime: Date.now() });
+  connectionStates.set(namespace, {
+    connecting: true,
+    lastConnectTime: Date.now(),
+  });
 
-  // 새 소켓 생성 (향상된 설정)
+  // 새 소켓 생성 (polling 우선으로 변경)
   const socket = io(fullUrl, {
-    transports: ["websocket", "polling"], // websocket 우선으로 변경
+    transports: ["polling", "websocket"], // polling 우선으로 변경
     auth: { token: jwt },
-    timeout: 10000, // 연결 타임아웃 10초
-    forceNew: true, // 새 연결 강제
+    timeout: 20000, // 연결 타임아웃 20초로 증가
+    forceNew: false, // 기존 연결 재사용 허용
     reconnection: true, // 자동 재연결 활성화
-    reconnectionAttempts: 3, // 재연결 시도 횟수 제한
-    reconnectionDelay: 1000, // 재연결 지연시간
-    reconnectionDelayMax: 3000, // 최대 재연결 지연시간
+    reconnectionAttempts: 5, // 재연결 시도 횟수 증가
+    reconnectionDelay: 2000, // 재연결 지연시간 증가
+    reconnectionDelayMax: 5000, // 최대 재연결 지연시간 증가
+    upgrade: true, // polling에서 websocket으로 업그레이드 허용
   });
 
   // 연결 성공 시 상태 업데이트
-  socket.on('connect', () => {
-    console.log('🟢 SOCKET CONNECTED:', fullUrl, socket.id);
-    connectionStates.set(namespace, { connecting: false, lastConnectTime: Date.now() });
+  socket.on("connect", () => {
+    console.log(`🟢 SOCKET CONNECTED [${namespace}]:`, fullUrl, socket.id);
+    connectionStates.set(namespace, {
+      connecting: false,
+      lastConnectTime: Date.now(),
+    });
   });
 
   // 연결 실패 시 처리
-  socket.on('connect_error', (error) => {
-    console.error('🔴 SOCKET CONNECTION ERROR:', fullUrl, error.message);
-    connectionStates.set(namespace, { connecting: false, lastConnectTime: Date.now() });
+  socket.on("connect_error", (error) => {
+    console.error(
+      `🔴 SOCKET CONNECTION ERROR [${namespace}]:`,
+      fullUrl,
+      error.message
+    );
+    connectionStates.set(namespace, {
+      connecting: false,
+      lastConnectTime: Date.now(),
+    });
   });
 
   // 재연결 시도 시
-  socket.on('reconnect_attempt', (attemptNumber) => {
-    console.log('🔄 SOCKET RECONNECT ATTEMPT:', attemptNumber, fullUrl);
+  socket.on("reconnect_attempt", (attemptNumber) => {
+    console.log(
+      `🔄 SOCKET RECONNECT ATTEMPT [${namespace}]:`,
+      attemptNumber,
+      fullUrl
+    );
   });
 
   // 재연결 성공 시
-  socket.on('reconnect', (attemptNumber) => {
-    console.log('🟢 SOCKET RECONNECTED:', fullUrl, 'attempts:', attemptNumber);
+  socket.on("reconnect", (attemptNumber) => {
+    console.log(
+      `🟢 SOCKET RECONNECTED [${namespace}]:`,
+      fullUrl,
+      "attempts:",
+      attemptNumber
+    );
   });
 
   // 재연결 실패 시 (모든 시도 소진)
-  socket.on('reconnect_failed', () => {
-    console.error('🔴 SOCKET RECONNECT FAILED:', fullUrl);
+  socket.on("reconnect_failed", () => {
+    console.error(`🔴 SOCKET RECONNECT FAILED [${namespace}]:`, fullUrl);
     // 소켓을 맵에서 제거하여 다음 요청시 새로 생성되도록 함
     sockets.delete(namespace);
     connectionStates.delete(namespace);
   });
 
   // 연결 해제 시
-  socket.on('disconnect', (reason) => {
-    console.log('🔴 SOCKET DISCONNECTED:', fullUrl, reason);
-    if (reason === 'io server disconnect' || reason === 'io client disconnect') {
+  socket.on("disconnect", (reason) => {
+    console.log(`🔴 SOCKET DISCONNECTED [${namespace}]:`, fullUrl, reason);
+    if (
+      reason === "io server disconnect" ||
+      reason === "io client disconnect"
+    ) {
       // 서버나 클라이언트에서 의도적으로 연결을 끊은 경우 재연결하지 않음
       sockets.delete(namespace);
       connectionStates.delete(namespace);
@@ -91,7 +126,7 @@ function createNewSocket(jwt: string, namespace: string, fullUrl: string): Socke
   });
 
   sockets.set(namespace, socket);
-  console.log("🔌 NEW SOCKET CONNECTING TO:", fullUrl);
+  console.log(`🔌 NEW SOCKET CONNECTING TO [${namespace}]:`, fullUrl);
 
   return socket;
 }
@@ -103,45 +138,37 @@ export function getSocket(namespace: string = "/") {
 export function disconnectSocket(namespace: string) {
   const socket = sockets.get(namespace);
   if (socket) {
-    console.log('🔌 DISCONNECTING SOCKET:', namespace);
+    console.log(`🔌 DISCONNECTING SOCKET [${namespace}]`);
     socket.removeAllListeners(); // 모든 이벤트 리스너 제거
     socket.disconnect();
     sockets.delete(namespace);
-
     connectionStates.delete(namespace);
-    console.log('✅ SOCKET DISCONNECTED AND CLEANED:', namespace);
-
-    console.log("🔌 SOCKET DISCONNECTED:", namespace);
-
+    console.log(`✅ SOCKET DISCONNECTED AND CLEANED [${namespace}]`);
   }
 }
 
 export function disconnectAllSockets() {
-  console.log('🔌 DISCONNECTING ALL SOCKETS');
+  console.log("🔌 DISCONNECTING ALL SOCKETS");
   sockets.forEach((socket, namespace) => {
     socket.removeAllListeners(); // 모든 이벤트 리스너 제거
     socket.disconnect();
-
-    console.log('✅ SOCKET DISCONNECTED:', namespace);
-
-    console.log("🔌 SOCKET DISCONNECTED:", namespace);
-
+    console.log(`✅ SOCKET DISCONNECTED [${namespace}]`);
   });
   sockets.clear();
   connectionStates.clear();
-  console.log('✅ ALL SOCKETS DISCONNECTED AND CLEANED');
+  console.log("✅ ALL SOCKETS DISCONNECTED AND CLEANED");
 }
 
 // 연결 상태 확인 함수 추가
-export function getSocketStatus(namespace: string = '/') {
+export function getSocketStatus(namespace: string = "/") {
   const socket = sockets.get(namespace);
   const state = connectionStates.get(namespace);
-  
+
   return {
     exists: !!socket,
     connected: socket?.connected ?? false,
     connecting: state?.connecting ?? false,
     id: socket?.id,
-    lastConnectTime: state?.lastConnectTime
+    lastConnectTime: state?.lastConnectTime,
   };
 }


### PR DESCRIPTION
# 일단 폴링 비활성화
- 주석만 남겨 놓았음. 더 효율적인 방법을 고민해봅시다.
- 3001번에 요청 너무 많이 가서 내 localhost 서버가 터져서 소켓 안 되는 거였음... 컴퓨터 껏다켜니 되더라.

# 협업 모드 무한 재접속 버그
- 기존에 `useChatMessages.ts`가 무한으로 호출돼서, 협업 모드 채팅방에서 계속 입장->퇴장 반복하는 문제 발생했음.
```js
  // 채팅방 업데이트 콜백을 useCallback으로 메모이제이션
  const handleChatRoomUpdate = useCallback(() => {
    // 협업 모드에서는 채팅방 목록을 관리하지 않으므로 빈 함수
  }, []);
  
  const {
    selectedMessages,
    text,
    setText,
    onSendMessage,
    onEditorKeyDown
  } = useChatMessages(
    true, // 항상 활성화
    selectedChatId, // 선택된 채팅방 ID
    token,
    session?.user?.id || null,
    handleChatRoomUpdate
  );
```
이러한 처리 통해 해결.