### PR TITLE
fix: 코너 스냅 1번만 더 고침

### DIFF
--- a/next/components/sim/mainsim/useObjectControls.js
+++ b/next/components/sim/mainsim/useObjectControls.js
@@ -240,17 +240,18 @@ export function useObjectControls(
       );
 
       // 두 개 이상의 가까운 벽이 있을 때 코너 스냅 시도 (현재 스냅된 벽 포함)
-      const candidatesForCorner = [
-        ...currentlySnapped,
-        ...nearCandidates,
-      ].filter(
-        (candidate, index, self) =>
-          // 중복 제거: 같은 벽의 같은 면은 하나만 유지
-          index ===
-          self.findIndex(
-            (c) => c.wall === candidate.wall && c.face === candidate.face
-          )
-      );
+      // O(n) deduplication using a Set for wall-face pairs
+      const seenWallFace = new Set();
+      const candidatesForCorner = [];
+      for (const candidate of [...currentlySnapped, ...nearCandidates]) {
+        // Use wall.id if available, otherwise fallback to wall reference
+        const wallId = candidate.wall && candidate.wall.id !== undefined ? candidate.wall.id : candidate.wall;
+        const key = `${wallId}:${candidate.face}`;
+        if (!seenWallFace.has(key)) {
+          seenWallFace.add(key);
+          candidatesForCorner.push(candidate);
+        }
+      }
 
       if (candidatesForCorner.length >= 2) {
         // 각 벽 조합을 확인하여 직각인지 체크

--- a/next/components/sim/mainsim/useObjectControls.js
+++ b/next/components/sim/mainsim/useObjectControls.js
@@ -277,7 +277,7 @@ export function useObjectControls(
                 const face = candidate.face;
 
                 // 벽의 회전각을 고려하여 실제 월드 축에서 어떤 제약인지 판단
-                const normalizedRotation = wallRotation % (2 * Math.PI);
+                const normalizedRotation = ((wallRotation % (2 * Math.PI)) + (2 * Math.PI)) % (2 * Math.PI);
 
                 // 벽이 X축 방향 (0도 또는 180도)인 경우
                 const isWallXAligned =


### PR DESCRIPTION
기존 코너 스냅이 잘 안되는 부분 1번만 더 수정함.

저도 100% 이해는 못해서 클로드의 설명을 가져왔어요.

```
문제가 뭐였나요?
벽에는 "앞면(front)", "뒷면(back)" 같은 이름이 있는데, 이게 벽 자체 기준이에요. 하지만 실제로는 **세상 전체 기준(월드 좌표계)**에서 어느 방향을 막는지 알아야 해요.
예시로 보면:
일반 벽 (가로로 놓인 벽)
======== (X축 방향 벽)

앞면/뒷면 → 남북(Z축) 방향 막음
왼쪽/오른쪽 → 동서(X축) 방향 막음

90도 돌린 벽 (세로로 놓인 벽)
||
||  (Z축 방향 벽)
||

앞면/뒷면 → 동서(X축) 방향 막음
왼쪽/오른쪽 → 남북(Z축) 방향 막음

코드가 하는 일:

벽이 가로인지 세로인지 확인 (회전각도로 판단)
면 이름을 실제 막는 방향으로 변환

가로벽: 앞뒤면=Z축 막음, 좌우면=X축 막음
세로벽: 앞뒤면=X축 막음, 좌우면=Z축 막음


왜 필요한가요?
코너 스냅핑할 때 "하나는 X축 막고, 하나는 Z축 막아야" 제대로 된 코너가 돼요. 이전에는 회전된 벽에서 잘못 판단해서 "둘 다 같은 축 막음"으로 나와서 코너가 안 됐던 거예요.
간단히 말해서 **"벽이 어떻게 돌아가 있든 실제로 어느 방향을 막는지 정확히 알아내는 똑똑한 함수"**라고 보시면 돼요!
```