### PR TITLE
fix: API 문서 swagger 정리 및 CacheManager path 설정 에러 수정

### DIFF
--- a/next/app/api/achievement/[id]/route.ts
+++ b/next/app/api/achievement/[id]/route.ts
@@ -1,6 +1,49 @@
 import { checkAchievement } from "@/lib/api/achievement/checkAchievement";
 import { NextRequest } from "next/server";
 
+
+/**
+ * @swagger
+ * /api/achievement/{id}:
+ *   get:
+ *     tags:
+ *       - Achievement
+ *     summary: 특정 유저의 업적 조회
+ *     description: 사용자 ID를 이용해 해당 사용자의 업적을 조회합니다.
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         description: 업적을 조회할 사용자 ID
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: 업적 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: string
+ *                   example: "123"
+ *                 achievements:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       name:
+ *                         type: string
+ *                         example: "First Chat"
+ *                       unlocked:
+ *                         type: boolean
+ *                         example: true
+ *       404:
+ *         description: 업적을 찾을 수 없음
+ *       500:
+ *         description: 서버 내부 오류
+ */
 export async function GET(req: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {

--- a/next/app/api/achievement/sse/route.ts
+++ b/next/app/api/achievement/sse/route.ts
@@ -1,6 +1,38 @@
 import { addSSEConnection, removeSSEConnection } from "@/lib/api/achievement/utils/sse";
 import { NextRequest } from "next/server";
 
+/**
+ * @swagger
+ * /api/achievement/sse:
+ * get:
+ * tags:
+ * - SSE
+ * summary: 업적을 위한 SSE 연결을 위한 초기 엔드포인트
+ * description: 업적을 위한 클라이언트-서버 간 Server-Sent Events (SSE) 연결을 설정합니다. `userId` 쿼리 파라미터가 필요하며, 연결 성공 시 초기 `connected` 메시지를 반환합니다.
+ * parameters:
+ * - in: query
+ * name: userId
+ * schema:
+ * type: string
+ * required: true
+ * description: 업적을 위한 SSE 연결을 위한 사용자 ID
+ * responses:
+ * '200':
+ * description: 업적을 위한 SSE 연결 성공
+ * content:
+ * text/event-stream:
+ * schema:
+ * type: string
+ * example: |
+ * data: {"type":"connected","message":"SSE 연결 성공","timeStamp":"2023-10-27T10:00:00.000Z"}
+ * '400':
+ * description: 유효하지 않은 요청
+ * content:
+ * text/plain:
+ * schema:
+ * type: string
+ * example: 'userId required'
+ */
 export async function GET(req: NextRequest) {
     console.log("🔫 GET 요청 받음");
     const userId = req.nextUrl.searchParams.get('userId');
@@ -32,7 +64,7 @@ export async function GET(req: NextRequest) {
             });
         },
     });
-    
+
     console.log("🔫 Response 반환 준비");
 
     return new Response(stream, {

--- a/next/app/api/backend/rooms/route.ts
+++ b/next/app/api/backend/rooms/route.ts
@@ -2,6 +2,101 @@ import { NextRequest, NextResponse } from "next/server";
 import { PrismaClient } from "@prisma/client";
 import { auth } from "@/lib/auth";
 
+
+/**
+ * @swagger
+ * /api/backend/rooms:
+ *   get:
+ *     tags:
+ *       - Chat
+ *     summary: 사용자가 참여 중인 채팅방 목록 조회
+ *     description: 로그인한 사용자가 참여하고 있는 채팅방 목록을 가져옵니다. 
+ *                  각 채팅방에는 최근 메시지, 참가자 정보, 읽은 시각 정보 등이 포함됩니다.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: 채팅방 목록 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     example: "clx123abc456"
+ *                   name:
+ *                     type: string
+ *                     nullable: true
+ *                     example: "Study Group"
+ *                   creator:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: "clu987xyz123"
+ *                       name:
+ *                         type: string
+ *                         example: "Alice"
+ *                   chat_messages:
+ *                     type: array
+ *                     description: 최근 메시지 1개만 포함
+ *                     items:
+ *                       type: object
+ *                       properties:
+ *                         id:
+ *                           type: string
+ *                           example: "msg001"
+ *                         content:
+ *                           type: string
+ *                           example: "안녕하세요!"
+ *                         created_at:
+ *                           type: string
+ *                           format: date-time
+ *                           example: "2025-09-13T12:34:56.000Z"
+ *                   chat_participants:
+ *                     type: array
+ *                     items:
+ *                       type: object
+ *                       properties:
+ *                         user_id:
+ *                           type: string
+ *                           example: "clu987xyz123"
+ *                         is_left:
+ *                           type: boolean
+ *                           example: false
+ *                         custom_room_name:
+ *                           type: string
+ *                           nullable: true
+ *                           example: "개인 스터디방"
+ *                         user:
+ *                           type: object
+ *                           properties:
+ *                             id:
+ *                               type: string
+ *                               example: "clu987xyz123"
+ *                             name:
+ *                               type: string
+ *                               example: "Alice"
+ *                   last_read_at:
+ *                     type: string
+ *                     format: date-time
+ *                     nullable: true
+ *                     example: "2025-09-13T09:00:00.000Z"
+ *                   updated_at:
+ *                     type: string
+ *                     format: date-time
+ *                     example: "2025-09-13T12:34:56.000Z"
+ *       401:
+ *         description: 인증 실패 (로그인 필요)
+ *       404:
+ *         description: 사용자 정보를 찾을 수 없음
+ *       500:
+ *         description: 서버 내부 오류
+ */
+
 const prisma = new PrismaClient();
 
 export async function GET(request: NextRequest) {

--- a/next/app/api/backend/route.ts
+++ b/next/app/api/backend/route.ts
@@ -1,21 +1,49 @@
-// 수정 필요
 /**
  * @swagger
- * /api/chat/token:
+ * /api/backend:
  *   get:
  *     tags:
- *       - chat token
- *     summary: 토큰 교환 + 소켓 준비
- *     description: 토큰 교환 + 소켓 준비
+ *       - User
+ *     summary: 사용자 검색
+ *     description: 이름을 기준으로 사용자를 검색합니다.
+ *     parameters:
+ *       - name: q
+ *         in: query
+ *         required: false
+ *         description: 검색할 사용자 이름(부분 일치 검색, 대소문자 무시)
+ *         schema:
+ *           type: string
+ *           example: "john"
+ *       - name: limit
+ *         in: query
+ *         required: false
+ *         description: 검색 결과 제한 개수 (기본값 10)
+ *         schema:
+ *           type: integer
+ *           example: 5
  *     responses:
  *       200:
- *         description: Successful response
+ *         description: 사용자 목록 조회 성공
  *         content:
  *           application/json:
  *             schema:
  *               type: array
  *               items:
  *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     example: "clx123abc456"
+ *                   name:
+ *                     type: string
+ *                     example: "John Doe"
+ *                   email:
+ *                     type: string
+ *                     example: "john@example.com"
+ *       404:
+ *         description: 사용자를 찾을 수 없음
+ *       500:
+ *         description: 서버 내부 오류
  */
 
 import { prisma } from "@/lib/prisma";

--- a/next/app/api/cache/route.ts
+++ b/next/app/api/cache/route.ts
@@ -2,6 +2,59 @@ import { CACHE_DIR } from "@/lib/cache/CacheUtils";
 import { prisma } from "@/lib/prisma";
 import fs from "fs/promises";
 
+/**
+ * @swagger
+ * /api/cache:
+ * get:
+ * tags:
+ * - Cache
+ * summary: 로컬 캐시된 모델을 DB에 업데이트
+ * description: 서버의 캐시 디렉토리(`CACHE_DIR`)에 저장된 3D 모델 파일(.glb)을 확인하고, 해당 파일 경로를 `prisma.furnitures` 테이블의 `cached_model_url` 필드에 업데이트합니다.
+ * responses:
+ * 200:
+ * description: 업데이트 성공
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * result:
+ * type: array
+ * description: Prisma 업데이트 결과 배열
+ * items:
+ * type: object
+ * files:
+ * type: array
+ * description: 캐시 디렉토리의 파일명 목록
+ * items:
+ * type: string
+ * details:
+ * type: array
+ * description: 파일 상세 정보 배열
+ * items:
+ * type: object
+ * properties:
+ * name:
+ * type: string
+ * size:
+ * type: number
+ * modified:
+ * type: string
+ * format: date-time
+ * isDirectory:
+ * type: boolean
+ * 500:
+ * description: 서버 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * description: 오류 메시지
+ */
+
 // 여태까지 저장 되었던 파일들을 cached_model_url로 넣기 위함
 async function GET() {
     try {

--- a/next/app/api/chat/download-image/route.ts
+++ b/next/app/api/chat/download-image/route.ts
@@ -9,6 +9,61 @@ const s3Client = new S3Client({
   },
 });
 
+/**
+ * @swagger
+ * /api/chat/download-image:
+ * get:
+ * tags:
+ * - Chat
+ * summary: S3에 저장된 이미지를 다운로드합니다.
+ * description: S3 키를 사용하여 지정된 이미지를 클라이언트에게 직접 다운로드할 수 있도록 제공합니다.
+ * parameters:
+ * - in: query
+ * name: s3Key
+ * schema:
+ * type: string
+ * required: true
+ * description: 다운로드할 이미지 파일의 S3 키
+ * example: "chat-images/example-image.jpg"
+ * responses:
+ * '200':
+ * description: 이미지 파일 다운로드 성공
+ * content:
+ * image/jpeg:
+ * schema:
+ * type: string
+ * format: binary
+ * '400':
+ * description: 유효하지 않은 요청 (S3 키 누락)
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "S3 키가 필요합니다"
+ * '404':
+ * description: 이미지를 찾을 수 없음
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "이미지를 찾을 수 없습니다"
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "이미지 다운로드에 실패했습니다"
+ */
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);

--- a/next/app/api/chat/image/[s3Key]/route.ts
+++ b/next/app/api/chat/image/[s3Key]/route.ts
@@ -9,6 +9,64 @@ const s3Client = new S3Client({
   },
 });
 
+/**
+ * @swagger
+ * /api/chat/image/{s3Key}:
+ * get:
+ * tags:
+ * - S3
+ * summary: S3에 저장된 이미지를 직접 표시합니다.
+ * description: |
+ * URL 경로에 포함된 `s3Key`에 해당하는 이미지를 S3 버킷에서 가져와 웹 브라우저에 직접 표시할 수 있는 `inline` 형태로 반환합니다.
+ * 이 API는 이미지 다운로드가 아닌, 이미지 태그(`<img>`)의 `src` 속성에 사용하기 적합합니다.
+ * parameters:
+ * - in: path
+ * name: s3Key
+ * required: true
+ * schema:
+ * type: string
+ * description: 표시할 이미지 파일의 URL 인코딩된 S3 키
+ * example: "chat-images%2Fexample-image.jpg"
+ * responses:
+ * '200':
+ * description: 이미지 파일 조회 성공
+ * content:
+ * image/jpeg:
+ * schema:
+ * type: string
+ * format: binary
+ * '400':
+ * description: 유효하지 않은 요청 (S3 키 누락)
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "S3 키가 필요합니다"
+ * '404':
+ * description: 이미지를 찾을 수 없음
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "이미지를 찾을 수 없습니다"
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "이미지를 불러올 수 없습니다"
+ */
+
 export async function GET(
   request: NextRequest,
   { params }: { params: { s3Key: string } }

--- a/next/app/api/chat/sse/notify/route.ts
+++ b/next/app/api/chat/sse/notify/route.ts
@@ -2,6 +2,119 @@ import { NextRequest, NextResponse } from 'next/server';
 import { sendToRoomParticipants, broadcastToChatUsers, debugChatConnections } from '../route';
 import { ChatSSEMessage } from '@/components/chat/types/chat-types';
 
+/**
+ * @swagger
+ * /api/chat/sse/notify:
+ * post:
+ * tags:
+ * - Chat
+ * - SSE
+ * summary: 채팅 관련 SSE 알림을 브로드캐스팅합니다.
+ * description: |
+ * 채팅방의 새 메시지, 읽음 상태 업데이트 등 실시간 이벤트를 SSE를 통해 모든 연결된 클라이언트에게 전송합니다.
+ * 요청 본문의 `type` 값에 따라 다른 종류의 알림을 브로드캐스팅합니다.
+ * requestBody:
+ * required: true
+ * content:
+ * application/json:
+ * schema:
+ * oneOf:
+ * - type: object
+ * required:
+ * - type
+ * - roomId
+ * - message
+ * - lastMessageAt
+ * - lastMessageSenderId
+ * properties:
+ * type:
+ * type: string
+ * description: 알림 타입. 'room_update'
+ * example: "room_update"
+ * roomId:
+ * type: string
+ * description: 업데이트된 채팅방 ID
+ * example: "chat-room-123"
+ * message:
+ * type: string
+ * description: 최신 메시지 내용
+ * example: "안녕하세요"
+ * lastMessageAt:
+ * type: string
+ * format: date-time
+ * description: 최신 메시지 전송 시간
+ * example: "2023-10-27T10:00:00.000Z"
+ * lastMessageSenderId:
+ * type: string
+ * description: 최신 메시지 발신자 ID
+ * example: "user-abc"
+ * messageType:
+ * type: string
+ * description: 메시지 타입 (e.g., text, image)
+ * example: "text"
+ * timestamp:
+ * type: string
+ * format: date-time
+ * description: 이벤트 발생 시간
+ * example: "2023-10-27T10:00:00.000Z"
+ * userId:
+ * type: string
+ * description: 알림 발신자의 사용자 ID
+ * example: "user-def"
+ * senderName:
+ * type: string
+ * description: 알림 발신자의 이름
+ * example: "김철수"
+ * senderImage:
+ * type: string
+ * description: 알림 발신자의 프로필 이미지 URL
+ * example: "https://example.com/profile.jpg"
+ * - type: object
+ * required:
+ * - type
+ * - roomId
+ * - userId
+ * properties:
+ * type:
+ * type: string
+ * description: 알림 타입. 'read_update'
+ * example: "read_update"
+ * roomId:
+ * type: string
+ * description: 업데이트된 채팅방 ID
+ * example: "chat-room-456"
+ * userId:
+ * type: string
+ * description: 읽음 상태를 업데이트한 사용자 ID
+ * example: "user-abc"
+ * timestamp:
+ * type: string
+ * format: date-time
+ * description: 이벤트 발생 시간
+ * example: "2023-10-27T10:05:00.000Z"
+ * responses:
+ * '200':
+ * description: 알림 브로드캐스팅 성공
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * success:
+ * type: boolean
+ * example: true
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "Failed to process SSE notification"
+ */
+
 export async function POST(request: NextRequest) {
   try {
     const data = await request.json() as ChatSSEMessage & {

--- a/next/app/api/chat/token/route.ts
+++ b/next/app/api/chat/token/route.ts
@@ -1,21 +1,48 @@
-// 수정 필요
 /**
  * @swagger
  * /api/chat/token:
- *   get:
- *     tags:
- *       - chat token
- *     summary: 토큰 교환 + 소켓 준비
- *     description: 토큰 교환 + 소켓 준비
- *     responses:
- *       200:
- *         description: Successful response
- *         content:
- *           application/json:
- *             schema:
- *               type: array
- *               items:
- *                 type: object
+ * get:
+ * tags:
+ * - Authentication
+ * summary: 세션 토큰의 유효성을 검증하고 새로운 JWT를 발급합니다.
+ * description: |
+ * 요청에 포함된 세션 쿠키를 기반으로 사용자의 토큰 유효성을 확인하고, 유효한 경우 새로운 JWT를 생성하여 반환합니다. 이 JWT는 특정 시간(1시간) 동안 유효하며, 사용자 ID를 포함합니다.
+ * responses:
+ * '200':
+ * description: 토큰 검증 성공 및 새 JWT 발급
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * token:
+ * type: string
+ * description: 유효성 검증 후 발급된 새로운 JWT
+ * example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjbGl2Z2Q1MjhjMDAxcnEwZDV5czI3ZXIxIiwiaWF0IjoxNjk4NDMwODAwLCJleHAiOjE2OTg0MzQ0MDB9.s1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0"
+ * userId:
+ * type: string
+ * description: 토큰에 포함된 사용자 ID
+ * example: "clivgnd528c001rq0d5ys27er1"
+ * '401':
+ * description: 토큰이 유효하지 않거나 존재하지 않음
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "No token"
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "토큰 발급 중 오류가 발생했습니다."
  */
 
 import { getToken } from "next-auth/jwt";

--- a/next/app/api/chat/upload-image/route.ts
+++ b/next/app/api/chat/upload-image/route.ts
@@ -10,6 +10,74 @@ const s3Client = new S3Client({
   },
 });
 
+/**
+ * @swagger
+ * /api/chat/upload-image:
+ * post:
+ * tags:
+ * - Chat
+ * summary: 이미지를 S3 버킷에 업로드합니다.
+ * description: 클라이언트로부터 받은 이미지 파일을 검증 후, 고유한 이름으로 S3 버킷에 업로드하고 S3 키를 반환합니다. 최대 10MB 크기의 이미지(JPEG, PNG 등)만 허용합니다.
+ * requestBody:
+ * required: true
+ * content:
+ * multipart/form-data:
+ * schema:
+ * type: object
+ * properties:
+ * image:
+ * type: string
+ * format: binary
+ * description: 업로드할 이미지 파일
+ * responses:
+ * '200':
+ * description: 이미지 업로드 성공
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * success:
+ * type: boolean
+ * example: true
+ * imageUrl:
+ * type: string
+ * description: S3 버킷에 저장된 파일의 키 (URL 아님)
+ * example: "chat/a1b2c3d4-e5f6-7890-1234-567890abcdef.jpg"
+ * filename:
+ * type: string
+ * description: 원본 파일명
+ * example: "my-photo.jpg"
+ * size:
+ * type: number
+ * description: 업로드된 파일 크기 (바이트)
+ * example: 524288
+ * type:
+ * type: string
+ * description: 파일 타입
+ * example: "image/jpeg"
+ * '400':
+ * description: 잘못된 요청
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "파일이 없습니다"
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "이미지 업로드에 실패했습니다"
+ */
+
 export async function POST(request: NextRequest) {
   try {
     const data = await request.formData();

--- a/next/app/api/compress-glb/route.ts
+++ b/next/app/api/compress-glb/route.ts
@@ -2,6 +2,78 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { NextRequest } from 'next/server';
 
+
+/**
+ * @swagger
+ * /api/compress-glb:
+ * post:
+ * tags:
+ * - 3D Model
+ * summary: 지정된 파일의 GLB 파일을 압축합니다.
+ * description: 요청 본문으로 제공된 디렉토리 경로에 있는 모든 GLB 파일을 gltf-pipeline 압축 라이브러리를 사용하여 최적화합니다.
+ * requestBody:
+ * required: true
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * required:
+ * - filePath
+ * properties:
+ * filePath:
+ * type: string
+ * description: 압축할 GLB 파일이 포함된 디렉토리의 절대 경로
+ * example: /path/to/your/glb/files
+ * responses:
+ * '200':
+ * description: 압축 성공
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * message:
+ * type: string
+ * example: GLB 파일 압축이 완료되었습니다.
+ * compressedCount:
+ * type: number
+ * description: 압축에 성공한 파일의 수
+ * '400':
+ * description: 잘못된 요청
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: 디렉토리 경로가 필요합니다.
+ * '405':
+ * description: 허용되지 않는 HTTP 메서드
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: Method not allowed
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: 압축 처리 중 오류가 발생했습니다.
+ * details:
+ * type: string
+ * example: '압축 라이브러리 실행 실패'
+ */
+
+
 const execAsync = promisify(exec);
 
 // Pages Router 방식

--- a/next/app/api/furniture/[id]/model/route.js
+++ b/next/app/api/furniture/[id]/model/route.js
@@ -1,6 +1,78 @@
 import { NextResponse } from "next/server";
 import { PrismaClient } from "@prisma/client";
 
+/**
+ * @swagger
+ * /api/furniture/{id}/model:
+ * get:
+ * tags:
+ * - 3D Model
+ * summary: 시뮬레이터용 가구 3D 모델을 조회하거나 생성합니다.
+ * description: |
+ * `id`에 해당하는 가구의 3D 모델을 조회합니다. 데이터베이스에 모델 URL이 있으면 즉시 반환하고, 없으면 이미지 URL을 기반으로 Trellis API를 통해 새로운 모델을 생성하여 반환합니다.
+ * parameters:
+ * - in: path
+ * name: id
+ * required: true
+ * schema:
+ * type: string
+ * description: 조회할 가구의 고유 ID
+ * responses:
+ * '200':
+ * description: 3D 모델 조회 또는 생성 성공
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * success:
+ * type: boolean
+ * example: true
+ * model_url:
+ * type: string
+ * description: 3D 모델의 URL
+ * example: "https://example.com/models/chair.glb"
+ * source:
+ * type: string
+ * enum: [existing, generated]
+ * description: 모델의 출처 ('existing'은 DB에 이미 존재, 'generated'는 새로 생성)
+ * example: "generated"
+ * message:
+ * type: string
+ * description: 모델이 새로 생성된 경우에만 반환
+ * example: "3D 모델이 생성되었습니다."
+ * '400':
+ * description: 유효하지 않은 요청 (이미지 URL 누락)
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "이미지 URL이 없어서 3D 모델을 생성할 수 없습니다."
+ * '404':
+ * description: 가구를 찾을 수 없음
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "가구를 찾을 수 없습니다."
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "3D 모델 로드 중 오류가 발생했습니다."
+ */
+
 const prisma = new PrismaClient();
 
 // 시뮬레이터용 가구 3D 모델 로드 API

--- a/next/app/api/model-upload/route.js
+++ b/next/app/api/model-upload/route.js
@@ -5,6 +5,86 @@ import { generateTrellisModel } from '../../trellis_api.js';
 import cacheUtils, { CACHE_DIR } from "@/lib/cache/CacheUtils";
 import path from 'path';
 
+
+/**
+ * @swagger
+ * /api/model-upload:
+ * post:
+ * tags:
+ * - 3D Model
+ * summary: 가구의 3D 모델을 생성하거나 기존 모델을 반환합니다.
+ * description: |
+ * - **기존 모델**: 요청된 `furniture_id`에 해당하는 가구에 이미 3D 모델 URL이 있는 경우, 해당 모델을 제공합니다. 이 과정에서 로컬 캐시를 확인하고, 없으면 S3에서 다운로드하여 캐시를 생성합니다.
+ * - **새 모델 생성**: 3D 모델 URL이 없는 경우, 가구의 이미지 URL을 사용하여 Trellis API로 새로운 3D 모델을 생성하고 S3에 업로드합니다.
+ * requestBody:
+ * required: true
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * required:
+ * - furniture_id
+ * properties:
+ * furniture_id:
+ * type: string
+ * description: 3D 모델을 요청할 가구의 고유 ID
+ * example: "furniture-12345"
+ * responses:
+ * '200':
+ * description: 3D 모델 생성 또는 제공 성공
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * success:
+ * type: boolean
+ * example: true
+ * furniture_id:
+ * type: string
+ * example: "furniture-12345"
+ * model_url:
+ * type: string
+ * description: 생성되거나 제공된 3D 모델의 URL
+ * example: "https://your-s3-bucket.s3.amazonaws.com/models/furniture-12345.glb"
+ * message:
+ * type: string
+ * example: "S3에 3D 모델 업로드 및 DB 업데이트 완료"
+ * cached:
+ * type: boolean
+ * description: 파일이 로컬 캐시에서 제공되었는지 여부
+ * example: true
+ * '400':
+ * description: 잘못된 요청
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "furniture_id가 필요합니다."
+ * '404':
+ * description: 가구를 찾을 수 없음
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "가구를 찾을 수 없습니다."
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "S3에 3D 모델 업로드에 실패했습니다: S3 연결 오류"
+ */
 export async function POST(request) {
   try {
     // 캐시 디렉토리 생성

--- a/next/app/api/models/[filename]/route.ts
+++ b/next/app/api/models/[filename]/route.ts
@@ -2,6 +2,36 @@ import { CACHE_DIR } from "@/lib/cache/CacheUtils";
 import { NextRequest } from "next/server";
 import fs from "fs/promises";
 
+/**
+ * @swagger
+ * /api/modles/{filename}:
+ *   get:
+ *     tags:
+ *       - Files
+ *     summary: 로컬에 파일 서빙
+ *     description: 
+ *       캐시 디렉토리(`CACHE_DIR`)에 저장된 `.glb` (glTF binary) 파일을 반환합니다.  
+ *       파일이 존재하지 않으면 404 에러를 반환합니다.
+ *     parameters:
+ *       - name: filename
+ *         in: path
+ *         required: true
+ *         description: 다운로드할 파일 이름 (예: `model.glb`)
+ *         schema:
+ *           type: string
+ *           example: "example_model.glb"
+ *     responses:
+ *       200:
+ *         description: 파일 다운로드 성공
+ *         content:
+ *           model/gltf-binary:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       404:
+ *         description: 파일을 찾을 수 없음
+ */
+
 // 로컬에 파일 서빙하는 서비스 로직
 export async function GET(
   request: NextRequest,

--- a/next/app/api/rooms/clone/route.ts
+++ b/next/app/api/rooms/clone/route.ts
@@ -3,6 +3,57 @@ import { auth } from "@/lib/auth";
 import type { NextRequest } from "next/server";
 import { Prisma } from "@prisma/client";
 
+/**
+ * @swagger
+ * /api/rooms/clone:
+ *   post:
+ *     tags:
+ *       - Rooms
+ *     summary: 기존 방 복제
+ *     description: 
+ *       주어진 `room_id`를 기반으로 기존 방을 복제하여 새로운 방을 생성합니다.  
+ *       새 방은 비공개(`is_public: false`)로 생성되며, 원본 방의 `title`, `description`, `room_data`, `thumbnail_url` 등을 복사합니다.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - room_id
+ *             properties:
+ *               room_id:
+ *                 type: string
+ *                 description: 복제할 방의 ID
+ *                 example: "room_123"
+ *     responses:
+ *       201:
+ *         description: 방 복제 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 room_id:
+ *                   type: string
+ *                   example: "room_456"
+ *                 message:
+ *                   type: string
+ *                   example: "Room cloned successfully"
+ *       400:
+ *         description: 필수 파라미터 누락 (`room_id` 없음)
+ *       401:
+ *         description: 인증 실패 (로그인 필요)
+ *       404:
+ *         description: 원본 방을 찾을 수 없음
+ *       500:
+ *         description: 서버 내부 오류
+ */
 export async function POST(req: NextRequest) {
   try {
     // 인증 확인

--- a/next/app/api/sim/furnitures/click/route.ts
+++ b/next/app/api/sim/furnitures/click/route.ts
@@ -4,6 +4,82 @@ import { NextRequest } from "next/server";
 import { getFurniture } from "@/lib/api/furniture/getFurnitures";
 import { checkUserOwnRoom } from "@/lib/api/achievement/checkUserOwnRoom";
 
+
+/**
+ * @swagger
+ * /api/sim/furnitures/click:
+ *   post:
+ *     tags:
+ *       - Furniture
+ *     summary: 방에 가구 추가 및 업적 달성 확인
+ *     description: 
+ *       사용자가 자신의 방에 새 가구를 추가할 때 업적 달성을 확인하고, 
+ *       새로 달성된 업적이 있다면 SSE 이벤트로 알림을 전송합니다.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - userId
+ *               - roomId
+ *               - newFurniture
+ *             properties:
+ *               userId:
+ *                 type: string
+ *                 description: 가구를 추가하는 사용자 ID
+ *                 example: "user_123"
+ *               roomId:
+ *                 type: string
+ *                 description: 가구를 추가할 방 ID
+ *                 example: "room_456"
+ *               newFurniture:
+ *                 type: object
+ *                 description: 새로 추가할 가구 정보
+ *                 example: 
+ *                   id: "furn_789"
+ *                   name: "Wooden Chair"
+ *                   type: "chair"
+ *     responses:
+ *       200:
+ *         description: 가구 추가 및 업적 확인 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 newlyUnlocked:
+ *                   type: array
+ *                   description: 새로 달성한 업적 목록
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: "achv_001"
+ *                       name:
+ *                         type: string
+ *                         example: "첫 번째 가구 배치"
+ *                 allAchievements:
+ *                   type: array
+ *                   description: 사용자가 현재까지 달성한 모든 업적
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: "achv_002"
+ *                       name:
+ *                         type: string
+ *                         example: "방 꾸미기 마스터"
+ *       403:
+ *         description: 유저가 해당 방의 소유자가 아님 (업적 달성 불가)
+ *       404:
+ *         description: 업적 데이터를 찾을 수 없음 또는 가구 저장 실패
+ *       500:
+ *         description: 서버 내부 오류
+ */
 export async function POST(request: NextRequest) {
     try {
         const { userId, roomId, newFurniture } = await request.json();

--- a/next/app/api/users/[id]/achievements/route.ts
+++ b/next/app/api/users/[id]/achievements/route.ts
@@ -1,6 +1,85 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAchievementsData, getUserAchievementsWithStatus } from "@/lib/api/achievement/achievements";
 
+/**
+ * @swagger
+ * /api/users/{id}/achievements:
+ *   post:
+ *     tags:
+ *       - Achievements
+ *     summary: 업적 생성
+ *     description: 새 업적 데이터를 생성합니다.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: 업적 데이터 배열 또는 단일 업적 객체 (createAchievementsData에 맞는 구조)
+ *             example:
+ *               - id: "achv_001"
+ *                 name: "첫 가구 배치"
+ *                 description: "방에 처음으로 가구를 배치하면 달성"
+ *               - id: "achv_002"
+ *                 name: "꾸미기 마스터"
+ *                 description: "방에 10개 이상의 가구를 배치하면 달성"
+ *     responses:
+ *       201:
+ *         description: 업적 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "sccuesfully created"
+ *                 status:
+ *                   type: integer
+ *                   example: 201
+ *       500:
+ *         description: 업적 생성 실패
+ * 
+ * /api/users/[id]/achievements:
+ *   get:
+ *     tags:
+ *       - Achievements
+ *     summary: 특정 유저의 업적 조회
+ *     description: 사용자 ID를 이용해 해당 사용자의 업적 목록과 달성 상태를 조회합니다.
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         description: 업적을 조회할 사용자 ID
+ *         schema:
+ *           type: string
+ *           example: "user_123"
+ *     responses:
+ *       200:
+ *         description: 업적 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     example: "achv_001"
+ *                   name:
+ *                     type: string
+ *                     example: "첫 가구 배치"
+ *                   description:
+ *                     type: string
+ *                     example: "방에 처음으로 가구를 배치하면 달성"
+ *                   unlocked:
+ *                     type: boolean
+ *                     example: true
+ *       500:
+ *         description: 업적 조회 실패
+ */
+
 export async function POST(request: NextRequest) {
   try {
     const datas = await request.json();

--- a/next/app/api/users/[id]/follow/route.ts
+++ b/next/app/api/users/[id]/follow/route.ts
@@ -2,6 +2,67 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 
+/**
+ * @swagger
+ * /api/users/{id}/follow:
+ *   post:
+ *     tags:
+ *       - User
+ *     summary: 사용자를 팔로우합니다.
+ *     description: |
+ *       로그인된 사용자가 `id`에 해당하는 사용자를 팔로우합니다.
+ *       이미 팔로우 중이면 400 에러를 반환합니다.
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         description: 팔로우할 사용자의 ID
+ *         schema:
+ *           type: string
+ *           example: "user123"
+ *     responses:
+ *       200:
+ *         description: 팔로우 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *       400:
+ *         description: 이미 팔로우 중인 사용자이거나 자기 자신을 팔로우하는 경우
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Already following this user"
+ *       401:
+ *         description: 인증되지 않은 사용자
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Unauthorized"
+ *       500:
+ *         description: 서버 내부 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Internal server error"
+ */
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }

--- a/next/app/api/users/[id]/followers/route.ts
+++ b/next/app/api/users/[id]/followers/route.ts
@@ -1,6 +1,62 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+/**
+ * @swagger
+ * /api/users/{id}/followers:
+ * get:
+ * tags:
+ * - User
+ * summary: 특정 사용자의 팔로워 목록을 조회합니다.
+ * description: |
+ * `id`에 해당하는 사용자의 팔로워 목록을 최신순으로 조회합니다.
+ * 각 팔로워의 ID, 이름, 이메일, 프로필 이미지, 팔로우한 날짜를 반환합니다.
+ * parameters:
+ * - in: path
+ * name: id
+ * required: true
+ * schema:
+ * type: string
+ * description: 사용자 ID (고유 식별자)
+ * responses:
+ * '200':
+ * description: 성공적으로 팔로워 목록을 조회했습니다.
+ * content:
+ * application/json:
+ * schema:
+ * type: array
+ * items:
+ * type: object
+ * properties:
+ * id:
+ * type: string
+ * example: "user-12345"
+ * name:
+ * type: string
+ * example: "홍길동"
+ * display_name:
+ * type: string
+ * example: "홍길동"
+ * profile_image:
+ * type: string
+ * nullable: true
+ * example: "https://example.com/profile.jpg"
+ * followed_at:
+ * type: string
+ * format: date-time
+ * example: "2023-10-27T10:00:00.000Z"
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "Internal server error"
+ */
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }

--- a/next/app/api/users/[id]/following/route.ts
+++ b/next/app/api/users/[id]/following/route.ts
@@ -1,6 +1,62 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+
+/**
+ * @swagger
+ * /api/users/{id}/following:
+ * get:
+ * tags:
+ * - User
+ * summary: 특정 사용자가 팔로우하는 사용자 목록을 조회합니다.
+ * description: |
+ * `id`에 해당하는 사용자가 팔로우하는 사용자 목록을 최신순으로 조회합니다.
+ * 각 사용자의 ID, 이름, 이메일, 프로필 이미지, 팔로우를 시작한 날짜를 반환합니다.
+ * parameters:
+ * - in: path
+ * name: id
+ * required: true
+ * schema:
+ * type: string
+ * description: 사용자 ID (고유 식별자)
+ * responses:
+ * '200':
+ * description: 성공적으로 팔로우 목록을 조회했습니다.
+ * content:
+ * application/json:
+ * schema:
+ * type: array
+ * items:
+ * type: object
+ * properties:
+ * id:
+ * type: string
+ * example: "user-67890"
+ * name:
+ * type: string
+ * example: "김철수"
+ * display_name:
+ * type: string
+ * example: "김철수"
+ * profile_image:
+ * type: string
+ * nullable: true
+ * example: "https://example.com/profile2.jpg"
+ * followed_at:
+ * type: string
+ * format: date-time
+ * example: "2023-10-27T10:00:00.000Z"
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "Internal server error"
+ */
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }

--- a/next/app/api/views/route.ts
+++ b/next/app/api/views/route.ts
@@ -1,6 +1,61 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+/**
+ * @swagger
+ * /api/views:
+ * post:
+ * tags:
+ * - Room
+ * summary: 특정 방의 조회수를 증가시킵니다.
+ * description: 요청 본문에 포함된 `room_id`에 해당하는 방의 조회수(`view_count`)를 1 증가시킵니다.
+ * requestBody:
+ * required: true
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * required:
+ * - room_id
+ * properties:
+ * room_id:
+ * type: string
+ * description: 조회수를 증가시킬 방의 고유 ID
+ * example: "room-abc-123"
+ * responses:
+ * '200':
+ * description: 조회수 업데이트 성공
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * views:
+ * type: number
+ * description: 업데이트된 방의 총 조회수
+ * example: 101
+ * '400':
+ * description: 유효하지 않은 요청
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "room_id가 필요합니다."
+ * '500':
+ * description: 서버 내부 오류
+ * content:
+ * application/json:
+ * schema:
+ * type: object
+ * properties:
+ * error:
+ * type: string
+ * example: "조회수 업데이트 중 오류가 발생했습니다."
+ */
+
 export async function POST(req: Request) {
   const { room_id } = await req.json();
 

--- a/next/lib/api/achievement/checkAchievement.ts
+++ b/next/lib/api/achievement/checkAchievement.ts
@@ -49,7 +49,7 @@ async function countUserHistory(userId: string) {
     };
 }
 
-export async function checkAchievement(userId: string, isFurniture: boolean) {
+export async function checkAchievement(userId: string, isFurniture: boolean = true) { // 집보다 가구일 확률이 높음
     const userHistory = await countUserHistory(userId);
     if (!userHistory) {
         return { error: 'User not found' };

--- a/next/lib/cache/CacheManager.ts
+++ b/next/lib/cache/CacheManager.ts
@@ -274,7 +274,7 @@ class CacheManager {
 }
 
 // 싱글톤 인스턴스 생성
-const CACHE_DIR = path.join(process.cwd());
+const CACHE_DIR = process.cwd(); // PROJECT ROOT 배포 시 에러 발생해서 이렇게 수정
 const cacheManager = new CacheManager(CACHE_DIR);
 
 export default cacheManager;


### PR DESCRIPTION
### AI를 이용해 Swagger 정리
<img width="429" height="753" alt="Screenshot 2025-09-13 at 1 09 47 AM" src="https://github.com/user-attachments/assets/573ec8ea-605e-4ea6-a701-a550d364da3c" />

### 배포 서버에서 path 에러 발생하여
수정 본
```typescript
const CACHE_DIR = process.cwd(); // PROJECT ROOT 배포 시 에러 발생해서 이렇게 수정
```

기존
```typescript
const CACHE_DIR = path.join(process.cwd()); // PROJECT ROOT 배포 시 에러 발생해서 이렇게 수정
```

근데 또 에러 발생할 수도?