### PR TITLE
fix: Simualtor Load Backend 리팩토링

### DIFF
--- a/next/app/api/model-upload/route.ts
+++ b/next/app/api/model-upload/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 // Trellis API 사용으로 변경
 import { generateTrellisModel } from '../../trellis_api.js';
@@ -85,14 +85,14 @@ import path from 'path';
  * type: string
  * example: "S3에 3D 모델 업로드에 실패했습니다: S3 연결 오류"
  */
-export async function POST(request) {
+export async function POST(request: NextRequest) {
   try {
     // 캐시 디렉토리 생성
     await cacheUtils.ensureCacheDir(CACHE_DIR);
 
     console.log('3D 모델 생성 API 호출됨')
     
-    const { furniture_id } = await request.json()
+    const { furniture_id } = await request.json();
     
     if (!furniture_id) {
       return NextResponse.json(
@@ -103,7 +103,12 @@ export async function POST(request) {
 
     // 1. DB에서 가구 정보 조회
     const furniture = await prisma.furnitures.findUnique({
-      where: { furniture_id: furniture_id }
+      where: { furniture_id: furniture_id },
+      select: {
+        model_url: true,
+        image_url: true,
+        name: true,
+      }
     })
 
     if (!furniture) {

--- a/next/app/api/rooms/clone/route.ts
+++ b/next/app/api/rooms/clone/route.ts
@@ -93,9 +93,9 @@ export async function POST(req: NextRequest) {
           user_id: session?.user?.id,
           title: `${original_room?.title}의 복제본`,
           description: original_room?.description,
-          room_data: original_room?.room_data
-            ? { pixelToMmRatio: original_room?.room_data.pixelToMmRatio }
-            : null,
+              // room_data: original_room?.room_data
+          //   ? { pixelToMmRatio: original_room?.room_data.pixelToMmRatio }
+          //   : null,
           thumbnail_url: original_room?.thumbnail_url,
           is_public: false,
           view_count: 0,

--- a/next/app/api/rooms/route.ts
+++ b/next/app/api/rooms/route.ts
@@ -183,9 +183,9 @@ export async function POST(req: NextRequest) {
           user_id: session.user.id,
           title,
           description,
-          room_data: room_data
-            ? { pixelToMmRatio: room_data.pixelToMmRatio }
-            : null,
+          // room_data: room_data
+          //   ? { pixelToMmRatio: room_data.pixelToMmRatio }
+          //   : null,
           is_public,
           view_count: 0,
         },

--- a/next/app/api/sim/load/[room_id]/route.ts
+++ b/next/app/api/sim/load/[room_id]/route.ts
@@ -1,8 +1,8 @@
-import cacheUtils from "@/lib/cache/CacheUtils";
 import { prisma } from "@/lib/prisma";
-import fs from "fs/promises";
+import { extractRoomInfo } from "@/lib/services/simulator/extractRoomInfo";
+import { objectTransformer } from "@/lib/services/simulator/objectTransformer";
+import { wallsToProcessor } from "@/lib/services/simulator/wallsToProcessor";
 import type { NextRequest } from "next/server";
-import path from "path";
 
 // URL 접근 가능 여부 확인 함수
 async function isUrlAccessible(url: string): Promise<boolean> {
@@ -110,6 +110,7 @@ export async function GET(
   try {
     const { room_id } = await params;
 
+    const startTime = Date.now();
     // room_id 유효성 검사
     if (!room_id) {
       return Response.json({ error: "room_id is required" }, { status: 400 });
@@ -117,222 +118,70 @@ export async function GET(
 
     console.log(`Loading objects for room: ${room_id}`);
 
-    // 1. 방이 존재하는지 확인
-    console.log("Step 1: Checking if room exists...");
-    const room = await prisma.rooms.findUnique({
-      where: { room_id: room_id },
-    });
+    // 쿼리 병렬 처리
+    const [room, roomObjects, roomWalls] = await Promise.all([
+      prisma.rooms.findUnique({ 
+        where: { room_id },
+        select: {
+          title: true,
+          description: true,
+          is_public: true,
+          updated_at: true,
+          wall_color: true,
+          floor_color: true,
+          background_color: true,
+          environment_preset: true,
+        }
+      }),
+      prisma.room_objects.findMany({ 
+        where: { room_id },
+        include: {
+          furnitures: {
+            select: {
+              furniture_id: true,
+              name: true,
+              model_url: true,
+              category_id: true,
+              length_x: true,
+              length_y: true,
+              length_z: true,
+              cached_model_url: true,
+            }
+          },
+        },
+        orderBy: {
+          created_at: "asc",
+        },
+      }),
+      prisma.room_walls.findMany({
+        where: { room_id },
+        orderBy: {
+          wall_order: "asc",
+        }
+      })
+    ]);
 
     if (!room) {
       console.log(`Room not found: ${room_id}`);
       return Response.json({ error: "Room not found" }, { status: 404 });
     }
 
-    console.log(`Room found: ${room.title}`);
-
-    // 2. room_objects와 furniture 정보, 그리고 벽 정보를 함께 조회
-    console.log("Step 2: Fetching room objects and walls...");
-    const roomObjects = await prisma.room_objects.findMany({
-      where: { room_id: room_id },
-      include: {
-        furnitures: {
-          select: {
-            furniture_id: true,
-            name: true,
-            model_url: true,
-            category_id: true,
-            length_x: true,
-            length_y: true,
-            length_z: true,
-            cached_model_url: true,
-          },
-        },
-      },
-      orderBy: {
-        created_at: "asc",
-      },
-    });
-
-    // 3. 벽 정보 조회
-    console.log("Step 3: Fetching room walls...");
-    const roomWalls = await prisma.room_walls.findMany({
-      where: { room_id: room_id },
-      orderBy: {
-        wall_order: "asc",
-      },
-    });
-
     console.log(
       `Found ${roomObjects.length} objects and ${roomWalls.length} walls for room ${room_id}`
     );
 
-    // // 각 객체의 furniture 관계 상태 확인
-    // roomObjects.forEach((obj, index) => {
-    //   console.log(
-    //     `Object ${index}: furniture_id=${obj.furniture_id}, length: ${obj.furnitures.length_x}, ${obj.furnitures.length_y}, ${obj.furnitures.length_z}`
-    //   );
-    // });
+    // 시뮬레이터에서 사용할 형태로 데이터 변환
+    const objects = await objectTransformer(roomObjects);
 
-    // // 벽 정보 로그
-    // roomWalls.forEach((wall, index) => {
-    //   console.log(
-    //     `Wall ${index}: length=${wall.length}, position=(${wall.position_x}, ${wall.position_y}, ${wall.position_z})`
-    //   );
-    // });
-
-    // 4. room_walls에 데이터가 없으면 rooms.room_data에서 fallback 시도
-    let legacyWallsData = [];
-    if (roomWalls.length === 0 && room.room_data) {
-      console.log(
-        "room_walls 테이블에 데이터가 없음. room_data에서 fallback 시도..."
-      );
-      const roomData = room.room_data as any;
-      if (roomData.walls && Array.isArray(roomData.walls)) {
-        console.log(`room_data에서 ${roomData.walls.length}개의 벽 발견`);
-
-        // legacy 데이터를 room_walls 형식으로 변환
-        const pixelToMmRatio = (roomData.pixelToMmRatio || 20) / 50;
-        legacyWallsData = roomData.walls.map((wall: any, index: number) => {
-          const startX = wall.start.x * pixelToMmRatio;
-          const startY = wall.start.y * pixelToMmRatio;
-          const endX = wall.end.x * pixelToMmRatio;
-          const endY = wall.end.y * pixelToMmRatio;
-
-          const length = Math.sqrt(
-            Math.pow(endX - startX, 2) + Math.pow(endY - startY, 2)
-          );
-
-          const positionX = (startX + endX) / 2;
-          const positionZ = (startY + endY) / 2;
-          const rotationY = Math.atan2(endY - startY, endX - startX);
-
-          return {
-            wall_id: `legacy-${index}`,
-            start_x: startX,
-            start_y: startY,
-            end_x: endX,
-            end_y: endY,
-            length: length,
-            height: 2.5,
-            depth: 0.2,
-            position_x: positionX,
-            position_y: 1.25,
-            position_z: positionZ,
-            rotation_x: 0,
-            rotation_y: rotationY,
-            rotation_z: 0,
-            wall_order: index,
-          };
-        });
-      }
-    }
-
-    // 4. 시뮬레이터에서 사용할 형태로 데이터 변환
-    const objects = await Promise.all(
-      roomObjects.map(async (obj) => {
-        // position JSON에서 값 추출
-        const pos = obj.position as any;
-        const rot = obj.rotation as any;
-        const scale = obj.scale as any;
-
-        // cached_model_url이 있으면 API 경로 사용, 없으면 원본 URL 사용
-        const hasCachedModel = obj.furnitures?.cached_model_url?.includes("/cache/models/");
-        const hasFurniture = obj.furnitures && obj.furniture_id;
-
-        if (hasCachedModel) {
-          console.log(
-            `🎃 Using cached file via API: ${obj.furnitures.cached_model_url}`
-          );
-        } 
-        else {
-          await processCacheMissing(obj);
-        }
-
-        return {
-          id: `object-${obj.object_id}`, // Three.js에서 사용할 고유 ID
-          object_id: obj.object_id, // DB의 객체 ID
-          furniture_id: obj.furniture_id,
-          name: hasFurniture ? obj.furnitures.name : "Custom Object", // InfoPanel에서 사용하는 name 속성
-          position: [pos?.x || 0, pos?.y || 0, pos?.z || 0],
-          rotation: [rot?.x || 0, rot?.y || 0, rot?.z || 0],
-          length: [
-            Number(obj.furnitures?.length_x),
-            Number(obj.furnitures?.length_y),
-            Number(obj.furnitures?.length_z),
-          ],
-          scale: [scale?.x || 1, scale?.y || 1, scale?.z || 1],
-          // furniture 테이블의 정보 활용 (furniture_id가 있는 경우만)
-          url:
-            hasFurniture && hasCachedModel
-              ? `/api/models/cache/${obj.furnitures.cached_model_url?.replace(
-                  "/cache/models/",
-                  ""
-                )}`
-              : obj.furnitures?.model_url || "/legacy_mesh (1).glb",
-          isCityKit: hasFurniture
-            ? obj.furnitures.model_url?.includes("citykit") || false
-            : false,
-          texturePath: null, // texture_url 필드가 스키마에 없음
-          type: hasFurniture
-            ? obj.furnitures.model_url?.endsWith(".glb")
-              ? "glb"
-              : "building"
-            : "custom",
-          // 추가 메타데이터
-          furnitureName: hasFurniture ? obj.furnitures.name : "Custom Object",
-          categoryId: hasFurniture ? obj.furnitures.category_id : null,
-        };
-      })
-    );
-
-    // 5. 벽 정보를 시뮬레이터 형태로 변환 (room_walls 또는 legacy data 사용)
-    const wallsToProcess = roomWalls.length > 0 ? roomWalls : legacyWallsData;
-    const walls = wallsToProcess.map((wall) => ({
-      id: `wall-${wall.wall_id}`,
-      wall_id: wall.wall_id,
-      start: { x: Number(wall.start_x), y: Number(wall.start_y) },
-      end: { x: Number(wall.end_x), y: Number(wall.end_y) },
-      length: Number(wall.length),
-      height: Number(wall.height),
-      depth: Number(wall.depth),
-      position: [
-        Number(wall.position_x),
-        Number(wall.position_y),
-        Number(wall.position_z),
-      ],
-      rotation: [
-        Number(wall.rotation_x),
-        Number(wall.rotation_y),
-        Number(wall.rotation_z),
-      ],
-      wall_order: wall.wall_order,
-    }));
+    // 벽 정보를 시뮬레이터 형태로 변환 (room_walls 또는 legacy data 사용)
+    const wallsToProcess = roomWalls.length > 0 ? roomWalls : [];
+    const walls = await wallsToProcessor(wallsToProcess);
 
     console.log(`최종 변환된 벽 개수: ${walls.length}`);
 
-    // 6. 벽, 바닥, 배경색 정보
-    const wall_color = room.wall_color || "#ffffff";
-    const floor_color = room.floor_color || "#d2b48c";
-    const background_color = room.background_color || "#87ceeb";
-    const environment_preset = room.environment_preset || "apartment";
-    const result: any = {
-      success: true,
-      room_id: room_id,
-      objects: objects,
-      walls: walls,
-      loaded_count: objects.length,
-      walls_count: walls.length,
-      room_info: {
-        title: room.title,
-        description: room.description,
-        is_public: room.is_public,
-        updated_at: room.updated_at,
-      },
-      wall_color: wall_color,
-      floor_color: floor_color,
-      background_color: background_color,
-      environment_preset: environment_preset,
-    };
+    // 벽, 바닥, 배경색 정보
+    const result = await extractRoomInfo(room, objects, walls, room_id);
+
     return Response.json(result);
   } catch (error) {
     console.error("Error loading simulator state:", error);
@@ -353,28 +202,5 @@ export async function GET(
       },
       { status: 500 }
     );
-  }
-}
-
-
-const processCacheMissing = async (obj: any) => {
-  console.log(`👿 Cache missing: ${obj.furnitures.name}`);
-  try {
-    const filename = `${obj.furnitures.furniture_id}.glb`;
-    const localPath = `public/cache/models/${filename}`;
-    const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
-
-    await fetch(`${baseUrl}/api/cache/miss`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", },
-      body: JSON.stringify({
-        furniture_id: obj.furnitures.furniture_id, 
-        localPath,
-      })
-    });
-    
-    await cacheUtils.downloadFileFromS3ToLocal(obj.furnitures, localPath, filename, obj.furnitures.furniture_id);
-  } catch (error) {
-    console.log("Cache missing 로컬 파일 캐싱 실패 😨:", error);
   }
 }

--- a/next/lib/api/fetchFurnitures.ts
+++ b/next/lib/api/fetchFurnitures.ts
@@ -33,21 +33,24 @@ export async function fetchFurnitures({
         const params = new URLSearchParams({
             page: page.toString(),
             limit: itemsPerPage.toString(),
+            ...(category && { category }),
+            ...(sort && { sort }),
+            ...(query && { query }),
         });
 
         // 카테고리가 선택되었다면 파라미터에 추가
-        if (category) {
-            params.append('category', category);
-        }
+        // if (category) {
+        //     params.append('category', category);
+        // }
 
-        // 정렬 옵션 추가
-        if (sort) {
-            params.append('sort', sort);
-        }
+        // // 정렬 옵션 추가
+        // if (sort) {
+        //     params.append('sort', sort);
+        // }
 
-        if (query) {
-            params.append("query", query);
-        }
+        // if (query) {
+        //     params.append("query", query);
+        // }
 
         const response = await fetch(`/api/sim/furnitures?${params}`, {
             method: 'GET',

--- a/next/lib/cache/CacheUtils.ts
+++ b/next/lib/cache/CacheUtils.ts
@@ -68,6 +68,7 @@ class CacheUtils {
       const result = NextResponse.json({
         success: true,
         furniture_id: furniture_id,
+        model_url: `/api/models/${fileName}`, // 로컬 서빙 URL
         message: "S3에서 다운로드 및 캐싱을 했습니다.",
         cached: false,
         downloaded: true,

--- a/next/lib/services/simulator/extractRoomInfo.ts
+++ b/next/lib/services/simulator/extractRoomInfo.ts
@@ -1,0 +1,28 @@
+import { RoomForLoadSim, SimulatorObject, SimualtorWall, SimualtorModel } from "@/types/simulator";
+
+export const extractRoomInfo = async (room: RoomForLoadSim, objects: SimulatorObject[], walls: SimualtorWall[], room_id: string) => {
+    const wall_color = room.wall_color || "#ffffff";
+    const floor_color = room.floor_color || "#d2b48c";
+    const background_color = room.background_color || "#87ceeb";
+    const environment_preset = room.environment_preset || "apartment";
+    const result: SimualtorModel = {
+        success: true,
+        room_id: room_id,
+        objects: objects,
+        walls: walls,
+        loaded_count: objects.length,
+        walls_count: walls.length,
+        room_info: {
+            title: room.title,
+            description: room.description,
+            is_public: room.is_public,
+            updated_at: room.updated_at,
+        },
+        wall_color: wall_color,
+        floor_color: floor_color,
+        background_color: background_color,
+        environment_preset: environment_preset,
+    }
+
+    return result; 
+}

--- a/next/lib/services/simulator/objectTransformer.ts
+++ b/next/lib/services/simulator/objectTransformer.ts
@@ -1,0 +1,84 @@
+import cacheUtils from "@/lib/cache/CacheUtils";
+import { RoomObjectTransformer } from "@/types/simulator";
+
+
+export const objectTransformer = async (roomObjects: RoomObjectTransformer[]) => {
+    return await Promise.all( 
+        roomObjects.map(async (obj) => {
+        // position JSON에서 값 추출
+        const pos = obj.position as any;
+        const rot = obj.rotation as any;
+        const scale = obj.scale as any;
+
+        // cached_model_url이 있으면 API 경로 사용, 없으면 원본 URL 사용
+        const hasCachedModel = obj.furnitures?.cached_model_url?.includes("/cache/models/");
+        const hasFurniture = obj.furnitures && obj.furniture_id;
+
+        if (hasCachedModel) {
+            console.log(
+            `🎃 Using cached file via API: ${obj.furnitures.cached_model_url}`
+            );
+        } 
+        else {
+            await processCacheMissing(obj);
+        }
+
+        return {
+            id: `object-${obj.object_id}`, // Three.js에서 사용할 고유 ID
+            object_id: obj.object_id, // DB의 객체 ID
+            furniture_id: obj.furniture_id,
+            name: hasFurniture ? obj.furnitures.name : "Custom Object", // InfoPanel에서 사용하는 name 속성
+            position: [pos?.x || 0, pos?.y || 0, pos?.z || 0],
+            rotation: [rot?.x || 0, rot?.y || 0, rot?.z || 0],
+            length: [
+            Number(obj.furnitures?.length_x),
+            Number(obj.furnitures?.length_y),
+            Number(obj.furnitures?.length_z),
+            ],
+            scale: [scale?.x || 1, scale?.y || 1, scale?.z || 1],
+            // furniture 테이블의 정보 활용 (furniture_id가 있는 경우만)
+            url:
+            hasFurniture && hasCachedModel
+                ? `/api/models/cache/${obj.furnitures.cached_model_url?.replace(
+                    "/cache/models/",
+                    ""
+                )}`
+                : obj.furnitures?.model_url || "/legacy_mesh (1).glb",
+            isCityKit: hasFurniture
+            ? obj.furnitures.model_url?.includes("citykit") || false
+            : false,
+            texturePath: null, // texture_url 필드가 스키마에 없음
+            type: hasFurniture
+            ? obj.furnitures.model_url?.endsWith(".glb")
+                ? "glb"
+                : "building"
+            : "custom",
+            // 추가 메타데이터
+            furnitureName: hasFurniture ? obj.furnitures.name : "Custom Object",
+            categoryId: hasFurniture ? obj.furnitures.category_id : null,
+        };
+        })
+    );
+}
+
+const processCacheMissing = async (obj: any) => {
+  console.log(`👿 Cache missing: ${obj.furnitures.name}`);
+  try {
+    const filename = `${obj.furnitures.furniture_id}.glb`;
+    const localPath = `public/cache/models/${filename}`;
+    const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+
+    await fetch(`${baseUrl}/api/cache/miss`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", },
+      body: JSON.stringify({
+        furniture_id: obj.furnitures.furniture_id, 
+        localPath,
+      })
+    });
+    
+    await cacheUtils.downloadFileFromS3ToLocal(obj.furnitures, localPath, filename, obj.furnitures.furniture_id);
+  } catch (error) {
+    console.log("Cache missing 로컬 파일 캐싱 실패 😨:", error);
+  }
+}

--- a/next/lib/services/simulator/wallsToProcessor.ts
+++ b/next/lib/services/simulator/wallsToProcessor.ts
@@ -1,0 +1,24 @@
+import { room_walls as Wall } from "@prisma/client";
+
+export const wallsToProcessor = async (wallsToProcess: Wall[]) => {
+    return wallsToProcess.map((wall) => ({
+        id: `wall-${wall.wall_id}`,
+        wall_id: wall.wall_id,
+        start: { x: Number(wall.start_x), y: Number(wall.start_y) },
+        end: { x: Number(wall.end_x), y: Number(wall.end_y) },
+        length: Number(wall.length),
+        height: Number(wall.height),
+        depth: Number(wall.depth),
+        position: [
+            Number(wall.position_x),
+            Number(wall.position_y),
+            Number(wall.position_z),
+        ],
+        rotation: [
+            Number(wall.rotation_x),
+            Number(wall.rotation_y),
+            Number(wall.rotation_z),
+        ],
+        wall_order: wall.wall_order,
+    }));
+}

--- a/next/prisma/schema.prisma
+++ b/next/prisma/schema.prisma
@@ -167,7 +167,6 @@ model rooms {
   user_id             String
   title               String          @db.VarChar(100)
   description         String?
-  room_data           Json?
   thumbnail_url       String?
   is_public           Boolean?        @default(true)
   view_count          Int?            @default(0)

--- a/next/types/simulator.ts
+++ b/next/types/simulator.ts
@@ -1,0 +1,80 @@
+import { Prisma } from "@prisma/client";
+
+export type SimulatorObject = {
+    id: string;
+    object_id: string;
+    furniture_id: string;
+    name: string;
+    position: number[];
+    rotation: number[];
+    length: number[];
+    scale: number[];
+    url: string;
+    isCityKit: boolean;
+    texturePath: null;
+    type: string;
+    furnitureName: string;
+    categoryId: number | null;
+};
+
+export type SimualtorWall = {
+    id: string;
+    wall_id: string;
+    start: { x: number, y: number };
+    end: { x: number, y: number };
+    length: number;
+    height: number;
+    depth: number;
+    position: number[];
+    rotation: number[];
+    wall_order: number | null;
+};
+
+export type SimualtorModel = {
+    success: boolean,
+    room_id: string,
+    objects: SimulatorObject[],
+    walls: SimualtorWall[],
+    loaded_count: number,
+    walls_count: number,
+    room_info: {
+        title: string | null,
+        description: string | null,
+        is_public: boolean | null,
+        updated_at: Date | null,
+    },
+    wall_color: string,
+    floor_color: string,
+    background_color: string,
+    environment_preset: string,
+}
+
+export type RoomObjectTransformer = Prisma.room_objectsGetPayload<{
+    include: {
+        furnitures: {
+            select: {
+                furniture_id: true;
+                name: true;
+                model_url: true;
+                category_id: true;
+                length_x: true;
+                length_y: true;
+                length_z: true;
+                cached_model_url: true;
+            }
+        }
+    }
+}>;
+
+export type RoomForLoadSim = Prisma.roomsGetPayload<{
+    select: {
+        title: true,
+        description: true,
+        is_public: true,
+        updated_at: true,
+        wall_color: true,
+        floor_color: true,
+        background_color: true,
+        environment_preset: true,
+    }
+}>

--- a/socket/src/chat/chat.gateway.ts
+++ b/socket/src/chat/chat.gateway.ts
@@ -21,7 +21,7 @@ type JoinPayload = { roomId: string };
 type LeavePayload = { roomId: string };
 type SendPayload = { roomId: string; content: string; tempId?: string };
 
-// @UseGuards(JwtAuthGuard) // 임시 비활성화
+@UseGuards(JwtAuthGuard) // 임시 비활성화
 @WebSocketGateway({
   cors: {
     origin: [/^http:\/\/localhost:\d+$/, 'https://wheretoput.store'],


### PR DESCRIPTION
## 1. 시뮬레이터 상에서 가구 클릭 시 호출되는 api 백엔드 수정
<img width="424" height="392" alt="Screenshot 2025-09-15 at 3 55 31 PM" src="https://github.com/user-attachments/assets/c85ff569-dcfd-4d33-b4d3-147e59204dbb" />

기존에는 `select *` 방식
```typescript
// 1. DB에서 가구 정보 조회
const furniture = await prisma.furnitures.findUnique({
  where: { furniture_id: furniture_id },
  select: {
    model_url: true,
    image_url: true,
    name: true,
  }
})
```
수정 본은 `필요한 컬럼만 select`

### 이유
SELECT * 가 더 빠른 경우
- **테이블이 작고 컬럼 수가 적을 때** (5-10개 컬럼 정도)
- **대부분의 컬럼을 실제로 사용할 때**
- **DB와 애플리케이션이 같은 서버에 있을 때** (네트워크 비용 무시 가능)
- **캐시 히트율이 높은 자주 조회되는 데이터**

선택적 조회가 더 빠른 경우
- **테이블에 컬럼이 많을 때** (20개 이상)
- **BLOB, TEXT 같은 큰 데이터 타입이 포함된 경우**
- **`네트워크 지연`이 있는 환경**
- **메모리가 제한적인 환경**

일단 컬럼이 엄청 많은 편은 아니지만, 꽤 있는 편이라 선택적 조회 하는게 그리고 현재는 조회하는 컬럼이 많지 않기 때문에
`select *` 이 더 비효율적이라고 판단

## 2. 시뮬레이터 접근 시 로드되는 백엔드 부분 수정

1. 직렬 query 처리에서 병렬 query로 수정

`수정 전`
<img width="333" height="116" alt="종호 방 수전 전" src="https://github.com/user-attachments/assets/da4b2dde-59c6-4517-91d9-4c407b7fd4b1" />

`수정 후`
<img width="559" height="168" alt="종호 집 DB 수정 후" src="https://github.com/user-attachments/assets/a6af31dd-c19c-48ff-9a17-ca0c59776e2b" />

매번 똑같은 속도를 나타내는건 아니지만 (방마다도 약간씩 다른거 같기도 하고...)
여러 번 테스트 해본 결과 약 1.7~1.8배 정도 단축 (원래 빨라서 별 체감은 안될 듯)

2. 함수 분리 및 모듈화
- 타입 정의
- 함수 분리