### PR TITLE
feat: 벽 + 바닥 재질 및 색 섞기 기능 / fix: 조명프리셋 비활성화

### DIFF
--- a/next/app/api/rooms/clone/route.ts
+++ b/next/app/api/rooms/clone/route.ts
@@ -87,7 +87,7 @@ export async function POST(req: NextRequest) {
 
     // 기존 방 정보를 복제하여 새로운 방을 생성
     const result = await prisma.$transaction(async (tx) => {
-      // 새 방 생성
+      // 새 방 생성 (색상/질감 정보 포함)
       const newRoom = await tx.rooms.create({
         data: {
           user_id: session?.user?.id,
@@ -100,6 +100,12 @@ export async function POST(req: NextRequest) {
           is_public: false,
           view_count: 0,
           root_room_id: original_room?.root_room_id || original_room.room_id,
+          wall_color: original_room?.wall_color || "#FFFFFF",
+          floor_color: original_room?.floor_color || "#D2B48C",
+          background_color: original_room?.background_color || "#87CEEB",
+          environment_preset: original_room?.environment_preset || "apartment",
+          wall_type: original_room?.wall_type || "color",
+          floor_type: original_room?.floor_type || "color",
         },
       });
 

--- a/next/app/api/sim/load/[room_id]/route.ts
+++ b/next/app/api/sim/load/[room_id]/route.ts
@@ -130,6 +130,8 @@ export async function GET(
           floor_color: true,
           background_color: true,
           environment_preset: true,
+          wall_type: true,
+          floor_type: true,
         }
       }),
       prisma.room_objects.findMany({ 

--- a/next/app/api/sim/save/route.ts
+++ b/next/app/api/sim/save/route.ts
@@ -102,6 +102,8 @@ export async function POST(req: NextRequest) {
       floorColor,
       backgroundColor,
       environmentPreset,
+      wallType,
+      floorType,
     } = body;
 
     // 필수 파라미터 확인
@@ -175,6 +177,8 @@ export async function POST(req: NextRequest) {
             floor_color: floorColor,
             background_color: backgroundColor,
             environment_preset: environmentPreset,
+            wall_type: wallType || "color",
+            floor_type: floorType || "color",
           },
         });
       } catch (roomUpdateError) {

--- a/next/components/sim/mainsim/ColorControlPanel.jsx
+++ b/next/components/sim/mainsim/ColorControlPanel.jsx
@@ -162,9 +162,14 @@ export function ColorControlPanel({ isPopup = false }) {
             </div>
           )}
 
-          {/* 색상 선택 - 단색 모드에서만 표시 */}
-          {(colorTarget === 'background' || (colorTarget === 'wall' && wallTexture === 'color') || (colorTarget === 'floor' && floorTexture === 'color')) && (
+          {/* 색상 선택 - 배경은 항상, 벽과 바닥은 텍스처와 함께 조합 가능 */}
+          {(colorTarget === 'background' || colorTarget === 'wall' || colorTarget === 'floor') && (
             <div>
+              <div style={{ fontSize: '14px', marginBottom: '8px', color: 'white' }}>
+                {colorTarget === 'background' ? '배경색' :
+                 colorTarget === 'wall' ? (wallTexture === 'color' ? '벽 색상' : '벽 색상 (텍스처와 조합)') :
+                 (floorTexture === 'color' ? '바닥 색상' : '바닥 색상 (텍스처와 조합)')}
+              </div>
               <HexColorPicker
                 // className="border-5 rounded-2xl" // 보더 필요 여부에 따라 수정
                 style={{
@@ -176,37 +181,6 @@ export function ColorControlPanel({ isPopup = false }) {
             </div>
           )}
 
-          {/* 벽지 텍스처 모드에서 색상 픽커 대신 안내 메시지 */}
-          {colorTarget === 'wall' && wallTexture !== 'color' && (
-            <div style={{
-              padding: '20px',
-              textAlign: 'center',
-              background: 'rgba(255,255,255,0.1)',
-              borderRadius: '8px',
-              border: '1px solid rgba(255,255,255,0.2)'
-            }}>
-              <div style={{ fontSize: '14px', color: 'rgba(255,255,255,0.8)' }}>
-                {wallTexturePresets[wallTexture].name} 벽지 적용중
-              </div>
-            
-            </div>
-          )}
-
-          {/* 바닥재 텍스처 모드에서 색상 픽커 대신 안내 메시지 */}
-          {colorTarget === 'floor' && floorTexture !== 'color' && (
-            <div style={{
-              padding: '20px',
-              textAlign: 'center',
-              background: 'rgba(255,255,255,0.1)',
-              borderRadius: '8px',
-              border: '1px solid rgba(255,255,255,0.2)'
-            }}>
-              <div style={{ fontSize: '14px', color: 'rgba(255,255,255,0.8)' }}>
-                {floorTexturePresets[floorTexture].name} 바닥 적용중
-              </div>
-              
-            </div>
-          )}
         </div>
       </div>
 

--- a/next/components/sim/mainsim/LightControlPanel.jsx
+++ b/next/components/sim/mainsim/LightControlPanel.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { useStore } from '@/components/sim/useStore'
+import React from "react";
+import { useStore } from "@/components/sim/useStore";
 
 export function LightControlPanel({ isPopup = false }) {
   const {
@@ -10,48 +10,60 @@ export function LightControlPanel({ isPopup = false }) {
     setEnvironmentPreset,
     setDirectionalLightAzimuth,
     setDirectionalLightElevation,
-    setDirectionalLightIntensity
-  } = useStore()
+    setDirectionalLightIntensity,
+  } = useStore();
 
   const baseStyle = {
-    background: 'rgba(0,0,0,0.7)',
-    padding: '15px',
-    borderRadius: '5px',
-    color: 'white',
-    fontSize: '13px',
-    width: '250px',
-    maxHeight: '400px',
-    overflowY: 'auto'
+    background: "rgba(0,0,0,0.7)",
+    padding: "15px",
+    borderRadius: "5px",
+    color: "white",
+    fontSize: "13px",
+    width: "250px",
+    maxHeight: "400px",
+    overflowY: "auto",
   };
 
-  const positionStyle = isPopup ? 
-    { position: 'static' } : 
-    { position: 'absolute', top: '50%', transform: 'translateY(-50%)', left: '10px', zIndex: 100 };
+  const positionStyle = isPopup
+    ? { position: "static" }
+    : {
+        position: "absolute",
+        top: "50%",
+        transform: "translateY(-50%)",
+        left: "10px",
+        zIndex: 100,
+      };
 
   return (
-    <div style={{
-      ...baseStyle,
-      ...positionStyle
-    }}>
-      <h3 style={{ margin: '0 0 10px 0', fontSize: '20px'}}
-      className="m-0 mb-2.5 text-xl font-semibold"> Lighting</h3>
+    <div
+      style={{
+        ...baseStyle,
+        ...positionStyle,
+      }}
+    >
+      <h3
+        style={{ margin: "0 0 10px 0", fontSize: "20px" }}
+        className="m-0 mb-2.5 text-xl font-semibold"
+      >
+        {" "}
+        Lighting
+      </h3>
 
       <div
         style={{
-          background: 'rgba(255,255,255,0.1)',
-          margin: '5px 0',
-          padding: '8px',
-          borderRadius: '3px',
-          border: '1px solid rgba(255,255,255,0.2)',
-          cursor: 'default'
+          background: "rgba(255,255,255,0.1)",
+          margin: "5px 0",
+          padding: "8px",
+          borderRadius: "3px",
+          border: "1px solid rgba(255,255,255,0.2)",
+          cursor: "default",
         }}
       >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
-
-          <LightPresetDropdown
+        <div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+          {/* <LightPresetDropdown
             value={environmentPreset}
             onChange={setEnvironmentPreset}
-          />
+          /> */}
           <ControlSlider
             label="방위각"
             value={directionalLightAzimuth}
@@ -82,7 +94,7 @@ export function LightControlPanel({ isPopup = false }) {
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 function ControlSlider({
@@ -95,16 +107,20 @@ function ControlSlider({
   displayValue,
 }) {
   return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center',
-       gap: '3px'
-    }}>
-      <span style={{
-        minWidth: '50px',
-        fontSize: '13px',
-        whiteSpace: 'nowrap'
-      }}>
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "3px",
+      }}
+    >
+      <span
+        style={{
+          minWidth: "50px",
+          fontSize: "13px",
+          whiteSpace: "nowrap",
+        }}
+      >
         {label}
       </span>
       <input
@@ -117,37 +133,37 @@ function ControlSlider({
         className="slider-small"
         style={{ flex: 1 }}
       />
-      <span style={{
-        color: '#ffffffff',
-        minWidth: '20px',
-        fontSize: '11px',
-        textAlign: 'right'
-      }}>
+      <span
+        style={{
+          color: "#ffffffff",
+          minWidth: "20px",
+          fontSize: "11px",
+          textAlign: "right",
+        }}
+      >
         {displayValue}
       </span>
     </div>
-  )
+  );
 }
 
 function LightPresetDropdown({ value, onChange }) {
   const presets = {
-    "아파트": "apartment",
-    "도시": "city",
-    "창고": "warehouse",
-    "일출": "dawn",
-    "일몰": "sunset",
-    "숲": "forest",
-    "로비": "lobby",
-    "밤": "night",
-    "공원": "park",
-    "스튜디오": "studio",
-  }
+    아파트: "apartment",
+    도시: "city",
+    창고: "warehouse",
+    일출: "dawn",
+    일몰: "sunset",
+    숲: "forest",
+    로비: "lobby",
+    밤: "night",
+    공원: "park",
+    스튜디오: "studio",
+  };
 
   return (
     <div className="mb-3">
-      <label className="block text-sm text-white mt-1 mb-2">
-        조명 프리셋
-      </label>
+      <label className="block text-sm text-white mt-1 mb-2">조명 프리셋</label>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -160,5 +176,5 @@ function LightPresetDropdown({ value, onChange }) {
         ))}
       </select>
     </div>
-  )
+  );
 }

--- a/next/components/sim/slices/roomSlice.js
+++ b/next/components/sim/slices/roomSlice.js
@@ -1,5 +1,3 @@
-import { generateSaveValues, parseLoadedValues } from "@/lib/textureUtils";
-
 export const roomSlice = (set, get) => ({
   currentRoomId: null,
   isSaving: false,
@@ -170,9 +168,6 @@ export const roomSlice = (set, get) => ({
         }
       }
 
-      // 텍스처 상태를 고려한 저장값 생성
-      const { wallValue, floorValue } = generateSaveValues(currentState);
-
       const furnResponse = await fetch("/api/sim/save", {
         method: "POST",
         headers: {
@@ -181,10 +176,12 @@ export const roomSlice = (set, get) => ({
         body: JSON.stringify({
           room_id: clonedId,
           objects: objects,
-          wallColor: wallValue,
-          floorColor: floorValue,
+          wallColor: currentState.wallColor,
+          floorColor: currentState.floorColor,
           backgroundColor: currentState.backgroundColor,
           environmentPreset: currentState.environmentPreset,
+          wallType: currentState.wallTexture,
+          floorType: currentState.floorTexture,
         }),
       });
 
@@ -288,10 +285,6 @@ export const roomSlice = (set, get) => ({
       }
       const currentState = get();
 
-      // 텍스처 상태를 고려한 저장값 생성
-      const { wallValue, floorValue } = generateSaveValues(currentState);
-
-
       if (currentState.wallsData.length > 0) {
         try {
           const scaledWalls = currentState.wallsData.map((wall) => ({
@@ -348,10 +341,12 @@ export const roomSlice = (set, get) => ({
         body: JSON.stringify({
           room_id: currentState.currentRoomId,
           objects: objects,
-          wallColor: wallValue,
-          floorColor: floorValue,
+          wallColor: currentState.wallColor,
+          floorColor: currentState.floorColor,
           backgroundColor: currentState.backgroundColor,
           environmentPreset: currentState.environmentPreset,
+          wallType: currentState.wallTexture,
+          floorType: currentState.floorTexture,
         }),
       });
 
@@ -441,31 +436,11 @@ export const roomSlice = (set, get) => ({
         }));
       }
 
-      // 현재 상태에서 텍스처 프리셋 가져오기
-      const currentState = get();
-
-      // environmentSlice에서 텍스처 프리셋 가져오기 (없으면 기본값 사용)
-      const wallTexturePresets = currentState.wallTexturePresets || {
-        color: { name: "단색", type: "color" },
-        stripe: { name: "스트라이프", type: "texture", texture: "/textures/wall_stripe.webp" },
-        marble: { name: "대리석", type: "texture", texture: "/textures/wall_marble.jpg" },
-        fabric: { name: "패브릭", type: "texture", texture: "/textures/wall_fabric_black.jpg" }
-      };
-
-      const floorTexturePresets = currentState.floorTexturePresets || {
-        color: { name: "단색", type: "color" },
-        tile: { name: "타일", type: "texture", texture: "/textures/tile_01.png" },
-        wood: { name: "마루", type: "texture", texture: "/textures/vintage_wood.jpg" },
-        marble: { name: "대리석", type: "texture", texture: "/textures/marble_01.png" }
-      };
-
-      // 로드된 값을 파싱하여 색상/텍스처 설정
-      const parsedEnvironment = parseLoadedValues(
-        result.wall_color || "#FFFFFF",
-        result.floor_color || "#D2B48C",
-        wallTexturePresets,
-        floorTexturePresets
-      );
+      // 직접 색상과 텍스처 정보 추출
+      const wallColor = result.wall_color || "#FFFFFF";
+      const floorColor = result.floor_color || "#D2B48C";
+      const wallTexture = result.wall_type || "color";
+      const floorTexture = result.floor_type || "color";
 
       set({
         loadedModels: loadedModels,
@@ -477,10 +452,10 @@ export const roomSlice = (set, get) => ({
           description: result.room_info?.description || "",
           is_public: result.room_info?.is_public || false,
         },
-        wallColor: parsedEnvironment.wallColor,
-        floorColor: parsedEnvironment.floorColor,
-        wallTexture: parsedEnvironment.wallTexture,
-        floorTexture: parsedEnvironment.floorTexture,
+        wallColor: wallColor,
+        floorColor: floorColor,
+        wallTexture: wallTexture,
+        floorTexture: floorTexture,
         backgroundColor: result.background_color || "#87CEEB",
         environmentPreset: result.environment_preset || "apartment",
       });

--- a/next/lib/services/simulator/extractRoomInfo.ts
+++ b/next/lib/services/simulator/extractRoomInfo.ts
@@ -5,6 +5,8 @@ export const extractRoomInfo = async (room: RoomForLoadSim, objects: SimulatorOb
     const floor_color = room.floor_color || "#d2b48c";
     const background_color = room.background_color || "#87ceeb";
     const environment_preset = room.environment_preset || "apartment";
+    const wall_type = room.wall_type || "color";
+    const floor_type = room.floor_type || "color";
     const result: SimualtorModel = {
         success: true,
         room_id: room_id,
@@ -22,7 +24,9 @@ export const extractRoomInfo = async (room: RoomForLoadSim, objects: SimulatorOb
         floor_color: floor_color,
         background_color: background_color,
         environment_preset: environment_preset,
+        wall_type: wall_type,
+        floor_type: floor_type,
     }
 
-    return result; 
+    return result;
 }

--- a/next/prisma/schema.prisma
+++ b/next/prisma/schema.prisma
@@ -179,6 +179,8 @@ model rooms {
   background_color    String          @default("#87CEEB")
   environment_preset  String          @default("apartment")
   collab_chat_room_id String?         @db.Uuid
+  wall_type           String?         @default("color")
+  floor_type          String?         @default("color")
   room_comments       room_comments[]
   room_likes          room_likes[]
   room_objects        room_objects[]

--- a/next/types/simulator.ts
+++ b/next/types/simulator.ts
@@ -47,6 +47,8 @@ export type SimualtorModel = {
     floor_color: string,
     background_color: string,
     environment_preset: string,
+    wall_type: string,
+    floor_type: string,
 }
 
 export type RoomObjectTransformer = Prisma.room_objectsGetPayload<{
@@ -76,5 +78,7 @@ export type RoomForLoadSim = Prisma.roomsGetPayload<{
         floor_color: true,
         background_color: true,
         environment_preset: true,
+        wall_type: true,
+        floor_type: true,
     }
 }>


### PR DESCRIPTION
# 조명프리셋 비활성화
<img width="382" height="373" alt="image" src="https://github.com/user-attachments/assets/5e1d2466-d06d-4ce6-963e-9b35662a5570" />

- 기존에 저희가 Environment 설정(조명 프리셋 설정)을 받을때 웹에 저장된 hdr 파일을 불러오는 식으로 했었는데요, 해당 사이트가 터져서 fetch 자체가 안되는 일이 생겨버렸습니다
- 최종발표 때 이런일이 있으면 망하는 거기 때문에, 조명프리셋을 일단 비활성화 해두고 기본 조명을 사용하게 코드 수정했습니다
- 조명 설정은 마지막주 QA 때 좀더 고민해봅시다

# 벽, 바닥 색감+질감 섞기
- 종호형 코드 기반으로 색감, 질감을 섞을 수 있게 처리했습니다
- 저장 및 웹소켓연동 잘됩니다
- texture 적용에는 아주살작의 시간이 걸립니다
<img width="1029" height="977" alt="image" src="https://github.com/user-attachments/assets/c189cf25-aaf2-48a5-ae7f-0d89eb481ad9" />
