### PR TITLE
fix: roomInfo 수정 시 바로 적용 안되는거 수정 및 업적 토스트 UI 변경

### DIFF
--- a/next/components/sim/SimSideView.tsx
+++ b/next/components/sim/SimSideView.tsx
@@ -8,9 +8,10 @@ import SideSort from "@/components/sim/side/SideSort";
 import SideItems from "@/components/sim/side/SideItems";
 import { HistoryControls, useHistoryKeyboard } from "@/components/sim/history";
 import type { furnitures as Furniture } from "@prisma/client";
+import { RoomInfo } from "@/lib/services/roomService";
 
 
-const SideViewContent: React.FC<{roomId: string, accessType: number, onEditClick: () => void }> = ({ roomId, accessType, onEditClick }) => {
+const SideViewContent: React.FC<{roomId: string, accessType: number, onEditClick: () => void; newRoomInfo: RoomInfo }> = ({ roomId, accessType, onEditClick, newRoomInfo }) => {
 
   const [collapsed, setCollapsed] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
@@ -46,6 +47,7 @@ const SideViewContent: React.FC<{roomId: string, accessType: number, onEditClick
         } bg-white text-black transition-all duration-300 flex flex-col border-r border-gray-200 select-none shadow-2xl drop-shadow-xl backdrop-blur-sm`}
       >
         <SideTitle
+          newRoomInfo={newRoomInfo}
           collapsed={collapsed}
           setCollapsed={setCollapsed}
           accessType={accessType}
@@ -113,16 +115,17 @@ const SideViewContent: React.FC<{roomId: string, accessType: number, onEditClick
   );
 };
 
-const SimSideView: React.FC<{ roomId: string | null; accessType: number; onEditClick: () => void }> = ({
+const SimSideView: React.FC<{ roomId: string | null; accessType: number; onEditClick: () => void; newRoomInfo: RoomInfo }> = ({
   roomId,
   accessType,
   onEditClick,
+  newRoomInfo,
 }) => {
   if (!roomId) {
     return null; // roomId가 없으면 아무것도 렌더링하지 않음
   }
 
-  return <SideViewContent roomId={roomId} accessType={accessType} onEditClick={onEditClick} />;
+  return <SideViewContent roomId={roomId} accessType={accessType} onEditClick={onEditClick} newRoomInfo={newRoomInfo}/>;
 };
 
 export default SimSideView;

--- a/next/components/sim/SimulatorCore.tsx
+++ b/next/components/sim/SimulatorCore.tsx
@@ -689,6 +689,7 @@ export function SimulatorCore({
           roomId={roomId}
           accessType={accessType}
           onEditClick={handleEditClick}
+          newRoomInfo={roomInfo}
         />
       )}
 

--- a/next/components/sim/achievement/ArchievementToast.tsx
+++ b/next/components/sim/achievement/ArchievementToast.tsx
@@ -54,8 +54,8 @@ export function ArchievementToast() {
         {/* 업적 토스트 */}
         {achievementToast && (
             <div className="fixed top-25 left-1/2 transform -translate-x-1/2 z-[200] max-w-sm">
-                <div className="bg-orange-500/80 backdrop-blur-sm text-white p-4 rounded-xl shadow-2xl border border-white/20">
-                    <div className="flex items-center gap-3 text-white">
+                <div className="flex items-center gap-3 text-white">
+                    <div className="tool-btn mt-3">
                         <div className="text-2xl drop-shadow-lg">{achievementToast.icon || '🏆'}</div>
                         <div>
                             <div className="font-bold text-sm drop-shadow-sm">새로운 업적 달성!</div>

--- a/next/components/sim/side/SideTitle.tsx
+++ b/next/components/sim/side/SideTitle.tsx
@@ -15,6 +15,7 @@ import ExitConfirmModal from "./ExitConfirmModal";
 
 // React 컴포넌트는 반드시 props 객체 하나만 받아야 하기 때문에 interface로 정의
 interface SideTitleProps {
+  newRoomInfo: RoomInfo;
   collapsed: boolean;
   setCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
   accessType: number; // 1: normal, 2: collaboration
@@ -22,15 +23,11 @@ interface SideTitleProps {
 }
 
 
-const SideTitle = ({ collapsed, setCollapsed, accessType, onEditClick }: SideTitleProps) => {
+const SideTitle = ({ newRoomInfo, collapsed, setCollapsed, accessType, onEditClick }: SideTitleProps) => {
   // 나가기 확인 모달 상태
   const [showExitModal, setShowExitModal] = useState(false);
   // 현재 방 정보
-  const [roomInfo, setRoomInfo] = useState<RoomInfo>({
-    title: "",
-    description: "",
-    is_public: false,
-  });
+  const [roomInfo, setRoomInfo] = useState<RoomInfo>(newRoomInfo);
   // 로딩 상태
   const [loading, setLoading] = useState(false);
 
@@ -42,25 +39,10 @@ const SideTitle = ({ collapsed, setCollapsed, accessType, onEditClick }: SideTit
   // 뒤로 가기 버튼
   const router = useRouter();
 
-  const { data: session } = useSession();
-
-
-  // 컴포넌트 마운트 시 또는 roomId 변경 시 방 정보 가져오기
+  // newRoomInfo 변경 시 방 정보 가져오기
   useEffect(() => {
-    const loadRoomInfo = async () => {
-      if (!currentRoomId) return;
-
-      setLoading(true);
-      try {
-        const info = await fetchRoomInfo(currentRoomId);
-        setRoomInfo(info);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadRoomInfo();
-  }, [currentRoomId]);
+    setRoomInfo(newRoomInfo);
+  }, [newRoomInfo])
 
   // 설정 버튼 클릭 시 부모 컴포넌트의 EditPopup 열기
   const handleSettingsClick = () => {


### PR DESCRIPTION
fix: roomInfo 수정 시 바로 적용 안되는거 수정 및 업적 토스트 UI 변경

```typescript
// newRoomInfo 변경 시 방 정보 가져오기
useEffect(() => {
  setRoomInfo(newRoomInfo);
}, [newRoomInfo])
```