### PR TITLE
fix: 사이드 접었다 펼때 Canvas 밀림 현상 bug fix

### DIFF
--- a/next/components/sim/SimSideView.tsx
+++ b/next/components/sim/SimSideView.tsx
@@ -11,7 +11,12 @@ import type { furnitures as Furniture } from "@prisma/client";
 import { RoomInfo } from "@/lib/services/roomService";
 
 
-const SideViewContent: React.FC<{roomId: string, accessType: number, onEditClick: () => void; newRoomInfo: RoomInfo }> = ({ roomId, accessType, onEditClick, newRoomInfo }) => {
+const SideViewContent: React.FC<{
+  roomId: string; 
+  accessType: number, 
+  onEditClick: () => void; 
+  newRoomInfo: RoomInfo;
+}> = ({ roomId, accessType, onEditClick, newRoomInfo }) => {
 
   const [collapsed, setCollapsed] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
@@ -53,8 +58,6 @@ const SideViewContent: React.FC<{roomId: string, accessType: number, onEditClick
           accessType={accessType}
           onEditClick={onEditClick}
         />
-
-
 
         <SideSearch 
           collapsed={collapsed}
@@ -115,7 +118,12 @@ const SideViewContent: React.FC<{roomId: string, accessType: number, onEditClick
   );
 };
 
-const SimSideView: React.FC<{ roomId: string | null; accessType: number; onEditClick: () => void; newRoomInfo: RoomInfo }> = ({
+const SimSideView: React.FC<{ 
+  roomId: string | null; 
+  accessType: number; 
+  onEditClick: () => void; 
+  newRoomInfo: RoomInfo; 
+}> = ({
   roomId,
   accessType,
   onEditClick,
@@ -125,7 +133,7 @@ const SimSideView: React.FC<{ roomId: string | null; accessType: number; onEditC
     return null; // roomId가 없으면 아무것도 렌더링하지 않음
   }
 
-  return <SideViewContent roomId={roomId} accessType={accessType} onEditClick={onEditClick} newRoomInfo={newRoomInfo}/>;
+  return <SideViewContent roomId={roomId} accessType={accessType} onEditClick={onEditClick} newRoomInfo={newRoomInfo} />;
 };
 
 export default SimSideView;

--- a/next/components/sim/SimulatorCore.tsx
+++ b/next/components/sim/SimulatorCore.tsx
@@ -723,7 +723,7 @@ export function SimulatorCore({
         />
       )}
 
-      <div className="flex-1 relative">
+      <div className="flex-1 min-w-0">
         {/* 모바일 헤더 */}
         {isMobile && (
           <MobileHeader roomInfo={currentRoomInfo} controlsRef={controlsRef} />


### PR DESCRIPTION
## 수정 내용

```typescript
<div className="flex-1 min-w-0">
```
기존 `relative` 에서 `min-w-0` 으로 수정


### 1. flex-1 의미
flex-grow: 1; flex-shrink: 1; flex-basis: 0% 의 축약형입니다.
의미:
flex-grow: 1 → 남는 공간 있으면 차지해라
flex-shrink: 1 → 공간 부족하면 줄어들어라
flex-basis: 0% → 기본 크기는 0, 계산은 grow/shrink에 따라 결정

즉, "사이드바 빼고 남은 영역 다 차지하는 메인 콘텐츠"가 됩니다.

### 2. min-w-0
flexbox에서 자주 빠뜨려서 생기는 버그 해결용입니다.

브라우저 기본값은 min-width: auto; → 자식 콘텐츠의 최소 크기만큼은 줄어들지 않음.
따라서 안에 긴 텍스트나 width: auto 요소가 있으면 사이드바가 밀려서 비율이 깨질 수 있음.
min-w-0을 주면 **“내용이 아무리 길어도 flex 규칙대로 줄어들 수 있다”**는 의미가 됩니다.