### PR TITLE
chore: 벽, 바닥 색을 #000000 으로 설정 시 원래 질감으로 복원

### DIFF
--- a/next/components/sim/SimulatorCore.tsx
+++ b/next/components/sim/SimulatorCore.tsx
@@ -60,219 +60,169 @@ import AutoSaveIndicator from "@/components/sim/save/AutoSaveIndicator";
 
 type position = [number, number, number];
 
-// 바닥 재질 컴포넌트 (textureUtils 사용)
-function FloorMaterial() {
-  const { floorColor, floorTexture, floorTexturePresets } = useStore();
-
-  // textureUtils로 현재 값 타입 확인
-  const { saveValues } = React.useMemo(() => {
-    const envState = {
-      floorTexture,
-      floorColor,
-      floorTexturePresets,
-      wallTexture: "color",
-      wallColor: "#969593",
-      wallTexturePresets: {},
-    };
-    return {
-      saveValues: generateSaveValues(envState),
-    };
-  }, [floorTexture, floorColor, floorTexturePresets]);
-
-  const valueType = determineValueType(saveValues.floorValue);
-  const currentPreset = floorTexturePresets[floorTexture];
-
-  // 텍스처 로드 (로딩 상태 관리)
-  const [texture, setTexture] = React.useState(null);
-  const [isTextureLoading, setIsTextureLoading] = React.useState(false);
-
-  React.useEffect(() => {
-    if (!valueType.isTexture || currentPreset?.type !== "texture") {
-      setTexture(null);
-      setIsTextureLoading(false);
-      return;
-    }
-
-    setIsTextureLoading(true);
-    const loader = new THREE.TextureLoader();
-
-    loader.load(
-      currentPreset.texture,
-      (loadedTexture) => {
-        loadedTexture.wrapS = loadedTexture.wrapT = THREE.RepeatWrapping;
-        loadedTexture.repeat.set(6, 6);
-        loadedTexture.minFilter = THREE.LinearFilter;
-        loadedTexture.magFilter = THREE.LinearFilter;
-        setTexture(loadedTexture);
-        setIsTextureLoading(false);
-      },
-      undefined,
-      (error) => {
-        console.error("Floor texture loading failed:", error);
-        setTexture(null);
-        setIsTextureLoading(false);
-      }
-    );
-  }, [valueType.isTexture, currentPreset?.texture, floorTexture]);
-
-  // 단일 material 생성 (조건에 따라 속성만 변경)
-  const material = React.useMemo(() => {
-    const mat = new THREE.MeshStandardMaterial();
-
-    // 텍스처 모드인데 아직 로딩중이거나 실패한 경우 색상 모드로 fallback
-    if (
-      valueType.isColor ||
-      currentPreset?.type === "color" ||
-      (valueType.isTexture &&
-        currentPreset?.type === "texture" &&
-        (!texture || isTextureLoading))
-    ) {
-      mat.color.set(floorColor);
-      mat.map = null;
-      mat.roughness = 0.9;
-      mat.metalness = 0.0;
-    } else if (
-      valueType.isTexture &&
-      texture &&
-      currentPreset?.type === "texture" &&
-      !isTextureLoading
-    ) {
-      mat.map = texture;
-      mat.color.set(floorColor);
-      mat.roughness = 0.9;
-      mat.metalness = 0.0;
-    } else {
-      // 안전한 fallback
-      mat.color.set(floorColor);
-      mat.map = null;
-      mat.roughness = 0.7;
-      mat.metalness = 0.0;
-    }
-
-    mat.needsUpdate = true;
-    return mat;
-  }, [
-    valueType.isColor,
-    valueType.isTexture,
-    currentPreset?.type,
-    floorColor,
-    texture,
-    floorTexture,
-    isTextureLoading,
-  ]);
-
-  return <primitive object={material} />;
+// 완전 검은색인지 판단하는 유틸리티 함수
+function isPureBlack(colorHex: string): boolean {
+  return colorHex.toLowerCase() === '#000000';
 }
 
-// 벽지 재질 컴포넌트 (textureUtils 사용)
+// 바닥 재질 컴포넌트 (깜빡임 방지 개선)
+function FloorMaterial() {
+  const { floorColor, floorTexture, floorTexturePresets } = useStore();
+  const currentPreset = floorTexturePresets[floorTexture];
+
+  // 모든 바닥재 텍스처를 미리 로드 (깜빡임 방지)
+  const allTextures = React.useMemo(() => {
+    const textureEntries = Object.entries(floorTexturePresets).filter(
+      ([_, preset]) => preset.type === "texture"
+    );
+    return textureEntries.map(([key, preset]) => preset.texture);
+  }, [floorTexturePresets]);
+
+  const preloadedTextures = useTexture(allTextures) as THREE.Texture[];
+
+  // 현재 선택된 텍스처 찾기
+  const currentTexture = React.useMemo(() => {
+    if (currentPreset.type !== "texture") return null;
+
+    const textureIndex = allTextures.indexOf(currentPreset.texture);
+    const texture = preloadedTextures[textureIndex];
+
+    if (texture && texture.image && texture.image.complete) {
+      texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+      texture.repeat.set(6, 6);
+      texture.minFilter = THREE.LinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+      texture.needsUpdate = true;
+    }
+
+    return texture;
+  }, [currentPreset, allTextures, preloadedTextures]);
+
+  // 단색 모드
+  if (currentPreset.type === "color") {
+    return (
+      <meshStandardMaterial
+        color={floorColor}
+        roughness={0.9}
+        metalness={0.0}
+      />
+    );
+  }
+
+  // 텍스처 모드 (프리로드된 텍스처 사용)
+  if (currentPreset.type === "texture" && currentTexture) {
+    const isBlackColor = isPureBlack(floorColor);
+
+    // 완전 검은색이면 색상 혼합 없이 순수 텍스처만 표시
+    if (isBlackColor) {
+      return (
+        <meshBasicMaterial
+          map={currentTexture}
+        />
+      );
+    } else {
+      // 다른 색상이면 색상 혼합
+      return (
+        <meshStandardMaterial
+          map={currentTexture}
+          color={floorColor}
+          roughness={0.9}
+          metalness={0.0}
+        />
+      );
+    }
+  }
+
+  // 로딩 중 fallback (이전 색상 유지)
+  return (
+    <meshStandardMaterial
+      color={floorColor}
+      roughness={0.7}
+      metalness={0.0}
+    />
+  );
+}
+
+// 벽지 재질 컴포넌트 (깜빡임 방지 개선)
 export function WallMaterial({ wallMaterialColor, transparent = true }) {
   const { wallColor, wallTexture, wallTexturePresets } = useStore();
-
-  // textureUtils로 현재 값 타입 확인
-  const { saveValues } = React.useMemo(() => {
-    const envState = {
-      wallTexture,
-      wallColor,
-      wallTexturePresets,
-      floorTexture: "color",
-      floorColor: "#875f32",
-      floorTexturePresets: {},
-    };
-    return {
-      saveValues: generateSaveValues(envState),
-    };
-  }, [wallTexture, wallColor, wallTexturePresets]);
-
-  const valueType = determineValueType(saveValues.wallValue);
   const currentPreset = wallTexturePresets[wallTexture];
 
-  // 텍스처 로드 (로딩 상태 관리)
-  const [texture, setTexture] = React.useState(null);
-  const [isTextureLoading, setIsTextureLoading] = React.useState(false);
-
-  React.useEffect(() => {
-    if (!valueType.isTexture || currentPreset?.type !== "texture") {
-      setTexture(null);
-      setIsTextureLoading(false);
-      return;
-    }
-
-    setIsTextureLoading(true);
-    const loader = new THREE.TextureLoader();
-
-    loader.load(
-      currentPreset.texture,
-      (loadedTexture) => {
-        // 벽지는 꽉채우기 모드
-        loadedTexture.wrapS = loadedTexture.wrapT = THREE.ClampToEdgeWrapping;
-        loadedTexture.repeat.set(1, 1);
-        loadedTexture.minFilter = THREE.LinearFilter;
-        loadedTexture.magFilter = THREE.LinearFilter;
-        setTexture(loadedTexture);
-        setIsTextureLoading(false);
-      },
-      undefined,
-      (error) => {
-        console.error("Wall texture loading failed:", error);
-        setTexture(null);
-        setIsTextureLoading(false);
-      }
+  // 모든 텍스처를 미리 로드 (깜빡임 방지)
+  const allTextures = React.useMemo(() => {
+    const textureEntries = Object.entries(wallTexturePresets).filter(
+      ([_, preset]) => preset.type === "texture"
     );
-  }, [valueType.isTexture, currentPreset?.texture, wallTexture]);
+    return textureEntries.map(([key, preset]) => preset.texture);
+  }, [wallTexturePresets]);
 
-  const finalColor = wallMaterialColor || wallColor;
+  const preloadedTextures = useTexture(allTextures) as THREE.Texture[];
 
-  // 단일 material 생성 (조건에 따라 속성만 변경)
-  const material = React.useMemo(() => {
-    const mat = new THREE.MeshStandardMaterial();
+  // 현재 선택된 텍스처 찾기
+  const currentTexture = React.useMemo(() => {
+    if (currentPreset.type !== "texture") return null;
 
-    // 텍스처 모드인데 아직 로딩중이거나 실패한 경우 색상 모드로 fallback
-    if (
-      valueType.isColor ||
-      currentPreset?.type === "color" ||
-      (valueType.isTexture &&
-        currentPreset?.type === "texture" &&
-        (!texture || isTextureLoading))
-    ) {
-      mat.color.set(finalColor);
-      mat.map = null;
-      mat.transparent = transparent;
-      mat.roughness = 0.8;
-      mat.metalness = 0.1;
-    } else if (
-      valueType.isTexture &&
-      texture &&
-      currentPreset?.type === "texture" &&
-      !isTextureLoading
-    ) {
-      mat.map = texture;
-      mat.color.set(finalColor);
-      mat.transparent = transparent;
-      mat.roughness = 0.8;
-      mat.metalness = 0.1;
-    } else {
-      // 안전한 fallback
-      mat.color.set(finalColor);
-      mat.map = null;
-      mat.transparent = transparent;
-      mat.roughness = 0.8;
-      mat.metalness = 0.1;
+    const textureIndex = allTextures.indexOf(currentPreset.texture);
+    const texture = preloadedTextures[textureIndex];
+
+    if (texture && texture.image && texture.image.complete) {
+      texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
+      texture.repeat.set(1, 1);
+      texture.minFilter = THREE.LinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+      texture.needsUpdate = true;
     }
 
-    mat.needsUpdate = true;
-    return mat;
-  }, [
-    valueType.isColor,
-    valueType.isTexture,
-    currentPreset?.type,
-    finalColor,
-    texture,
-    wallTexture,
-    transparent,
-    isTextureLoading,
-  ]);
+    return texture;
+  }, [currentPreset, allTextures, preloadedTextures]);
 
-  return <primitive object={material} />;
+  // 단색 모드
+  if (currentPreset.type === "color") {
+    return (
+      <meshStandardMaterial
+        color={wallMaterialColor || wallColor}
+        transparent={transparent}
+        roughness={0.8}
+        metalness={0.1}
+      />
+    );
+  }
+
+  // 텍스처 모드 (프리로드된 텍스처 사용)
+  if (currentPreset.type === "texture" && currentTexture) {
+    const isBlackColor = isPureBlack(wallColor);
+
+    // 완전 검은색이면 색상 혼합 없이 순수 텍스처만 표시
+    if (isBlackColor) {
+      return (
+        <meshBasicMaterial
+          map={currentTexture}
+          transparent={transparent}
+        />
+      );
+    } else {
+      // 다른 색상이면 색상 혼합
+      return (
+        <meshStandardMaterial
+          map={currentTexture}
+          color={wallMaterialColor || wallColor}
+          transparent={transparent}
+          roughness={0.8}
+          metalness={0.1}
+        />
+      );
+    }
+  }
+
+  // 로딩 중 fallback (이전 색상 유지)
+  return (
+    <meshStandardMaterial
+      color={wallMaterialColor || wallColor}
+      transparent={transparent}
+      roughness={0.8}
+      metalness={0.1}
+    />
+  );
 }
 
 // 동적 바닥 - 벽 데이터에 따라 내부 영역에만 바닥 렌더링

--- a/next/components/sim/mainsim/control/ColorControlPanel.jsx
+++ b/next/components/sim/mainsim/control/ColorControlPanel.jsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { useStore } from '@/components/sim/useStore';
+import { useStore } from "@/components/sim/useStore";
 import { HexColorPicker } from "react-colorful";
-
 
 export function ColorControlPanel({ isPopup = false }) {
   const {
@@ -16,103 +15,146 @@ export function ColorControlPanel({ isPopup = false }) {
     setFloorTexture,
     wallTexture,
     wallTexturePresets,
-    setWallTexture
+    setWallTexture,
   } = useStore();
-  const [colorTarget, setColorTarget] = React.useState('wall'); // 'wall' | 'floor' | 'background'
+  const [colorTarget, setColorTarget] = React.useState("wall"); // 'wall' | 'floor' | 'background'
+  const [originalColors, setOriginalColors] = React.useState({
+    wall: wallColor,
+    floor: floorColor
+  });
+  const [isBlackFromOriginal, setIsBlackFromOriginal] = React.useState({
+    wall: false,
+    floor: false
+  });
 
   const baseStyle = {
-    background: 'rgba(0,0,0,0.7)',
-    padding: '15px',
-    borderRadius: '5px',
-    color: 'white',
-    fontSize: '13px',
-    width: '250px',
-    maxHeight: '400px',
-    overflowY: 'auto'
+    background: "rgba(0,0,0,0.7)",
+    padding: "15px",
+    borderRadius: "5px",
+    color: "white",
+    fontSize: "13px",
+    width: "250px",
+    maxHeight: "400px",
+    overflowY: "auto",
   };
 
-  const positionStyle = isPopup ?
-    { position: 'static' } :
-    { position: 'absolute', top: '50%', transform: 'translateY(-50%)', left: '10px', zIndex: 100 };
+  const positionStyle = isPopup
+    ? { position: "static" }
+    : {
+        position: "absolute",
+        top: "50%",
+        transform: "translateY(-50%)",
+        left: "10px",
+        zIndex: 100,
+      };
 
   return (
-    <div style={{
-      ...baseStyle,
-      ...positionStyle
-    }}>
-      <h3 style={{ margin: '0 0 10px 0', fontSize: '20px' }} className="m-0 mb-2.5 text-xl font-semibold"> Colors </h3>
+    <div
+      style={{
+        ...baseStyle,
+        ...positionStyle,
+      }}
+    >
+      <h3
+        style={{ margin: "0 0 10px 0", fontSize: "20px" }}
+        className="m-0 mb-2.5 text-xl font-semibold"
+      >
+        {" "}
+        Colors{" "}
+      </h3>
 
       <div
         style={{
-          background: 'rgba(255,255,255,0.1)',
-          margin: '5px 0',
-          padding: '8px',
-          borderRadius: '3px',
-          border: '1px solid rgba(255,255,255,0.2)',
-          cursor: 'default'
+          background: "rgba(255,255,255,0.1)",
+          margin: "5px 0",
+          padding: "8px",
+          borderRadius: "3px",
+          border: "1px solid rgba(255,255,255,0.2)",
+          cursor: "default",
         }}
       >
         <div className="flex items-center justify-center mt-1 mb-2">
           <div className="flex justify-center bg-gray-200 rounded-lg overflow-hidden">
             <button
-              className={`px-3 py-1 text-xs transition-colors cursor-pointer ${colorTarget === "wall"
-                ? "bg-blue-500 text-white"
-                : "text-gray-600 hover:bg-gray-300"
-                }`}
+              className={`px-3 py-1 text-xs transition-colors cursor-pointer ${
+                colorTarget === "wall"
+                  ? "bg-blue-500 text-white"
+                  : "text-gray-600 hover:bg-gray-300"
+              }`}
               onClick={() => setColorTarget("wall")}
             >
               벽
             </button>
             <button
-              className={`px-3 py-1 text-xs transition-colors cursor-pointer ${colorTarget === "floor"
-                ? "bg-blue-500 text-white"
-                : "text-gray-600 hover:bg-gray-300"
-                }`}
+              className={`px-3 py-1 text-xs transition-colors cursor-pointer ${
+                colorTarget === "floor"
+                  ? "bg-blue-500 text-white"
+                  : "text-gray-600 hover:bg-gray-300"
+              }`}
               onClick={() => setColorTarget("floor")}
             >
               바닥
             </button>
             <button
-              className={`px-3 py-1 text-xs transition-colors cursor-pointer ${colorTarget === "background"
-                ? "bg-blue-500 text-white"
-                : "text-gray-600 hover:bg-gray-300"
-                }`}
+              className={`px-3 py-1 text-xs transition-colors cursor-pointer ${
+                colorTarget === "background"
+                  ? "bg-blue-500 text-white"
+                  : "text-gray-600 hover:bg-gray-300"
+              }`}
               onClick={() => setColorTarget("background")}
             >
               배경
             </button>
           </div>
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
           {/* 벽 옵션 클릭시 벽지 옵션 표시 */}
-          {colorTarget === 'wall' && (
-            <div style={{ marginBottom: '10px' }}>
-              <div style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', color: 'white' }}>벽지 타입</div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '5px' }}>
-
+          {colorTarget === "wall" && (
+            <div style={{ marginBottom: "10px" }}>
+              <div
+                style={{
+                  fontSize: "14px",
+                  fontWeight: "bold",
+                  marginBottom: "8px",
+                  color: "white",
+                }}
+              >
+                벽지 타입
+              </div>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "5px" }}>
                 {/* [09.15] 동적으로 여러개의 벽지 UI 생성 */}
                 {Object.entries(wallTexturePresets).map(([key, preset]) => (
                   <button
                     key={key}
                     style={{
-                      padding: '4px 8px',
-                      fontSize: '12px',
-                      border: '1px solid rgba(255,255,255,0.3)',
-                      borderRadius: '4px',
-                      background: wallTexture === key ? 'rgba(59, 130, 246, 0.8)' : 'rgba(255,255,255,0.1)',
-                      color: 'white',
-                      cursor: 'pointer',
-                      transition: 'all 0.2s'
+                      padding: "4px 8px",
+                      fontSize: "12px",
+                      border: "1px solid rgba(255,255,255,0.3)",
+                      borderRadius: "4px",
+                      background:
+                        wallTexture === key
+                          ? "rgba(59, 130, 246, 0.8)"
+                          : "rgba(255,255,255,0.1)",
+                      color: "white",
+                      cursor: "pointer",
+                      transition: "all 0.2s",
                     }}
-                    onClick={() => setWallTexture(key)}
+                    onClick={() => {
+                      // 단색으로 전환할 때 원본질감 상태 확인 후 원래 색상 복원
+                      if (key === 'color' && isBlackFromOriginal.wall && wallColor === '#000000') {
+                        setWallColor(originalColors.wall);
+                        setIsBlackFromOriginal(prev => ({ ...prev, wall: false }));
+                      }
+                      setWallTexture(key);
+                    }}
                     onMouseEnter={(e) => {
                       if (wallTexture !== key) {
-                        e.target.style.background = 'rgba(255,255,255,0.2)';
+                        e.target.style.background = "rgba(255,255,255,0.2)";
                       }
                     }}
                     onMouseLeave={(e) => {
                       if (wallTexture !== key) {
-                        e.target.style.background = 'rgba(255,255,255,0.1)';
+                        e.target.style.background = "rgba(255,255,255,0.1)";
                       }
                     }}
                   >
@@ -124,34 +166,52 @@ export function ColorControlPanel({ isPopup = false }) {
           )}
 
           {/* 바닥 옵션 클릭시  바닥재 옵션 표시 */}
-          {colorTarget === 'floor' && (
-            <div style={{ marginBottom: '10px' }}>
-              <div style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', color: 'white' }}>바닥재 타입</div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '5px' }}>
-
+          {colorTarget === "floor" && (
+            <div style={{ marginBottom: "10px" }}>
+              <div
+                style={{
+                  fontSize: "14px",
+                  fontWeight: "bold",
+                  marginBottom: "8px",
+                  color: "white",
+                }}
+              >
+                바닥재 타입
+              </div>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "5px" }}>
                 {/*[09.15] 동적으로 여러개의 바닥재 UI 생성 */}
                 {Object.entries(floorTexturePresets).map(([key, preset]) => (
                   <button
                     key={key}
                     style={{
-                      padding: '4px 8px',
-                      fontSize: '12px',
-                      border: '1px solid rgba(255,255,255,0.3)',
-                      borderRadius: '4px',
-                      background: floorTexture === key ? 'rgba(59, 130, 246, 0.8)' : 'rgba(255,255,255,0.1)',
-                      color: 'white',
-                      cursor: 'pointer',
-                      transition: 'all 0.2s'
+                      padding: "4px 8px",
+                      fontSize: "12px",
+                      border: "1px solid rgba(255,255,255,0.3)",
+                      borderRadius: "4px",
+                      background:
+                        floorTexture === key
+                          ? "rgba(59, 130, 246, 0.8)"
+                          : "rgba(255,255,255,0.1)",
+                      color: "white",
+                      cursor: "pointer",
+                      transition: "all 0.2s",
                     }}
-                    onClick={() => setFloorTexture(key)}
+                    onClick={() => {
+                      // 단색으로 전환할 때 원본질감 상태 확인 후 원래 색상 복원
+                      if (key === 'color' && isBlackFromOriginal.floor && floorColor === '#000000') {
+                        setFloorColor(originalColors.floor);
+                        setIsBlackFromOriginal(prev => ({ ...prev, floor: false }));
+                      }
+                      setFloorTexture(key);
+                    }}
                     onMouseEnter={(e) => {
                       if (floorTexture !== key) {
-                        e.target.style.background = 'rgba(255,255,255,0.2)';
+                        e.target.style.background = "rgba(255,255,255,0.2)";
                       }
                     }}
                     onMouseLeave={(e) => {
                       if (floorTexture !== key) {
-                        e.target.style.background = 'rgba(255,255,255,0.1)';
+                        e.target.style.background = "rgba(255,255,255,0.1)";
                       }
                     }}
                   >
@@ -163,27 +223,104 @@ export function ColorControlPanel({ isPopup = false }) {
           )}
 
           {/* 색상 선택 - 배경은 항상, 벽과 바닥은 텍스처와 함께 조합 가능 */}
-          {(colorTarget === 'background' || colorTarget === 'wall' || colorTarget === 'floor') && (
+          {(colorTarget === "background" ||
+            colorTarget === "wall" ||
+            colorTarget === "floor") && (
             <div>
-              <div style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', color: 'white' }}>
-                {colorTarget === 'background' ? '배경색' :
-                 colorTarget === 'wall' ? (wallTexture === 'color' ? '벽 색상' : '벽 색상 (텍스처와 조합)') :
-                 (floorTexture === 'color' ? '바닥 색상' : '바닥 색상 (텍스처와 조합)')}
+              <div
+                style={{
+                  fontSize: "14px",
+                  fontWeight: "bold",
+                  marginBottom: "8px",
+                  color: "white",
+                }}
+              >
+                {colorTarget === "background"
+                  ? "배경색"
+                  : colorTarget === "wall"
+                  ? wallTexture === "color"
+                    ? "벽 색상"
+                    : "벽 색상 (텍스처와 조합)"
+                  : floorTexture === "color"
+                  ? "바닥 색상"
+                  : "바닥 색상 (텍스처와 조합)"}
               </div>
               <HexColorPicker
                 // className="border-5 rounded-2xl" // 보더 필요 여부에 따라 수정
                 style={{
-                  width: '100%',
-                  height: '120px'
+                  width: "100%",
+                  height: "120px",
                 }}
-                color={colorTarget === 'wall' ? wallColor : colorTarget === 'floor' ? floorColor : backgroundColor}
-                onChange={colorTarget === 'wall' ? setWallColor : colorTarget === 'floor' ? setFloorColor : setBackgroundColor} />
+                color={
+                  colorTarget === "wall"
+                    ? wallColor
+                    : colorTarget === "floor"
+                    ? floorColor
+                    : backgroundColor
+                }
+                onChange={(color) => {
+                  // 색상 변경 시 원본질감 상태 해제
+                  if (colorTarget === "wall") {
+                    if (color !== '#000000') {
+                      setOriginalColors(prev => ({ ...prev, wall: color }));
+                      setIsBlackFromOriginal(prev => ({ ...prev, wall: false }));
+                    }
+                    setWallColor(color);
+                  } else if (colorTarget === "floor") {
+                    if (color !== '#000000') {
+                      setOriginalColors(prev => ({ ...prev, floor: color }));
+                      setIsBlackFromOriginal(prev => ({ ...prev, floor: false }));
+                    }
+                    setFloorColor(color);
+                  } else {
+                    setBackgroundColor(color);
+                  }
+                }}
+              />
             </div>
           )}
 
+          {/* 질감 모드일 때 색 없애기 버튼 추가 */}
+          {((colorTarget === "wall" && wallTexture !== "color") ||
+            (colorTarget === "floor" && floorTexture !== "color")) && (
+            <div style={{ marginTop: "10px" }}>
+              <button
+                style={{
+                  padding: "4px 8px",
+                  fontSize: "12px",
+                  border: "1px solid rgba(255,255,255,0.3)",
+                  borderRadius: "4px",
+                  background: "rgba(255, 255, 255, 0.1)",
+                  color: "white",
+                  cursor: "pointer",
+                  transition: "all 0.2s",
+                }}
+                onClick={() => {
+                  if (colorTarget === "wall") {
+                    // 원본 색상 저장하고 원본질감 상태 설정
+                    setOriginalColors(prev => ({ ...prev, wall: wallColor }));
+                    setIsBlackFromOriginal(prev => ({ ...prev, wall: true }));
+                    setWallColor("#000000");
+                  } else if (colorTarget === "floor") {
+                    // 원본 색상 저장하고 원본질감 상태 설정
+                    setOriginalColors(prev => ({ ...prev, floor: floorColor }));
+                    setIsBlackFromOriginal(prev => ({ ...prev, floor: true }));
+                    setFloorColor("#000000");
+                  }
+                }}
+                onMouseEnter={(e) => {
+                  e.target.style.background = "rgba(59, 130, 246, 0.8)";
+                }}
+                onMouseLeave={(e) => {
+                  e.target.style.background = "rgba(255, 255, 255, 0.1)";
+                }}
+              >
+                원본 질감
+              </button>
+            </div>
+          )}
         </div>
       </div>
-
     </div>
-  )
+  );
 }


### PR DESCRIPTION
이건 좀 꼼수인데 벽, 바닥 질감 있을 때 색이 #000000(완전 검은색)이면 어차피 질감이 표시 안됩니다. 검정으로 염색이 돼서

그래서 색을 #000000으로 설정하면 색을 안 입히게끔 설정했습니다.

컬러 패널에 '원본 질감' 버튼을 누르면 색이 자동으로 #000000으로 바뀝니다.

이때 편의성을 위해 '원본 질감' 누르고 질감->단색으로 바꾸는 경우, state에 저장된 버튼 누르기 전 기존 색이 자동으로 복원되게끔 설정했습니다.
(물론 그 후에 색을 다시 수정하는 경우, 질감->단색으로 바꿔도 바뀐 색이 유지됩니다)

<img width="1030" height="749" alt="image" src="https://github.com/user-attachments/assets/db3e1c2d-f919-4672-a02e-ac58ade8e1e6" />
