### PR TITLE
fix: width, depth 비율 보정

### DIFF
--- a/next/cache-medata.json
+++ b/next/cache-medata.json
@@ -1,0 +1,49 @@
+{
+  "files": {
+    "29f24ab5-fdb9-4798-98a1-8d67a72a3853.glb": {
+      "lastAccessed": "2025. 9. 18. 오후 12:47:55",
+      "accessCount": 3,
+      "fileSize": 146444,
+      "createdAt": "2025. 9. 18. 오후 12:42:14"
+    },
+    "0d0a6766-8139-4be6-a1d8-a0d34409731b.glb": {
+      "lastAccessed": "2025. 9. 18. 오후 12:42:15",
+      "accessCount": 1,
+      "fileSize": 126860,
+      "createdAt": "2025. 9. 18. 오후 12:42:15"
+    },
+    "2d736429-be0d-4b76-b74c-770a614291b4.glb": {
+      "lastAccessed": "2025. 9. 18. 오후 12:49:57",
+      "accessCount": 3,
+      "fileSize": 108672,
+      "createdAt": "2025. 9. 18. 오후 12:42:32"
+    },
+    "2bc3fba8-6286-4e51-854c-e9b60a9225f6.glb": {
+      "lastAccessed": "2025. 9. 18. 오후 12:45:08",
+      "accessCount": 1,
+      "fileSize": 153800,
+      "createdAt": "2025. 9. 18. 오후 12:45:08"
+    },
+    "74257a89-f6ec-4a10-84f1-bc90a9d76dc7.glb": {
+      "lastAccessed": "2025. 9. 18. 오후 12:49:59",
+      "accessCount": 1,
+      "fileSize": 60716,
+      "createdAt": "2025. 9. 18. 오후 12:49:59"
+    },
+    "7f3db827-7271-47f6-80da-9faee57d43b8.glb": {
+      "lastAccessed": "2025. 9. 18. 오후 12:50:06",
+      "accessCount": 1,
+      "fileSize": 94260,
+      "createdAt": "2025. 9. 18. 오후 12:50:06"
+    },
+    "a09a5887-80d4-4809-b334-a6219751245f.glb": {
+      "lastAccessed": "2025. 9. 18. 오후 12:50:31",
+      "accessCount": 1,
+      "fileSize": 69992,
+      "createdAt": "2025. 9. 18. 오후 12:50:31"
+    }
+  },
+  "totalSize": 760744,
+  "maxSize": 52428800,
+  "lastCleanup": "2025. 9. 18. 오후 12:42:14"
+}

--- a/next/components/sim/mainsim/DraggableModel.jsx
+++ b/next/components/sim/mainsim/DraggableModel.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useMemo } from "react";
+import React, { useRef, useEffect, useMemo, useState } from "react";
 import { useTexture, useGLTF, Html } from "@react-three/drei";
 import * as THREE from "three";
 import { useObjectControls } from "@/components/sim/mainsim/hooks/useObjectControls";
@@ -67,6 +67,7 @@ export function DraggableModel({
   const isHovering = hoveringModelId === modelId;
 
   const originalSizeRef = useRef([1, 1, 1]);
+  const [needsRotation, setNeedsRotation] = useState(false);
   // 선택 표시 박스 크기 결정 (회전 고려)
   const getSelectionBoxSize = useCallback(() => {
     if (!meshRef.current) {
@@ -147,6 +148,11 @@ export function DraggableModel({
         actualW >= actualD
           ? [Math.max(lengthW, lengthD), Math.min(lengthW, lengthD)]
           : [Math.min(lengthW, lengthD), Math.max(lengthW, lengthD)];
+
+      // mappedX가 actualD를 따라가고, mappedZ가 actualW를 따라가는 경우 90도 회전
+
+      const rotationNeeded = (lengthW > lengthD && actualW < actualD) || (lengthW < lengthD && actualW > actualD);
+      setNeedsRotation(rotationNeeded);
 
       const targetScale = [
         (mappedX * 0.001) / actualW,
@@ -265,7 +271,11 @@ export function DraggableModel({
         <group
           ref={meshRef}
           position={position}
-          rotation={rotation}
+          rotation={[
+            rotation[0],
+            rotation[1] + (needsRotation ? Math.PI / 2 : 0),
+            rotation[2],
+          ]}
           scale={safeScale}
         >
           <primitive object={scene.clone()} />
@@ -279,7 +289,11 @@ export function DraggableModel({
         <group
           ref={meshRef}
           position={position}
-          rotation={rotation}
+          rotation={[
+            rotation[0],
+            rotation[1] + (needsRotation ? Math.PI / 2 : 0),
+            rotation[2],
+          ]}
           scale={safeScale}
         >
           {scene ? (

--- a/next/components/sim/mainsim/DraggableModel.jsx
+++ b/next/components/sim/mainsim/DraggableModel.jsx
@@ -136,10 +136,23 @@ export function DraggableModel({
       box.getSize(modelSize);
       originalSizeRef.current = [modelSize.x, modelSize.y, modelSize.z];
 
-      // 목표 크기로 스케일 조정
-      const targetScale = safeScale.map(
-        (target, i) => target / modelSize.getComponent(i)
-      );
+      // GLTF 실제 크기와 length 배열 매핑하여 스케일 조정
+      const actualW = modelSize.x,
+        actualD = modelSize.z;
+      const lengthW = length[0],
+        lengthD = length[2];
+
+      // 큰 것끼리, 작은 것끼리 매핑
+      const [mappedX, mappedZ] =
+        actualW >= actualD
+          ? [Math.max(lengthW, lengthD), Math.min(lengthW, lengthD)]
+          : [Math.min(lengthW, lengthD), Math.max(lengthW, lengthD)];
+
+      const targetScale = [
+        (mappedX * 0.001) / actualW,
+        safeScale[1] / modelSize.y,
+        (mappedZ * 0.001) / actualD,
+      ];
 
       meshRef.current.scale.set(...targetScale);
 

--- a/next/components/sim/mainsim/SelectedModelSidebar.jsx
+++ b/next/components/sim/mainsim/SelectedModelSidebar.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useStore } from "@/components/sim/useStore";
 import { useHistory, ActionType } from "@/components/sim/history";
-import { useDeleteKey }  from "@/components/sim/mainsim/hooks/useDeleteKey";
+import { useDeleteKey } from "@/components/sim/mainsim/hooks/useDeleteKey";
 import { RotationControl } from "@/components/sim/mainsim/control/RotationControl";
 import { CollapsibleSidebar } from "./CollapsibleSidebar";
 import { handleStackModel as stackModel } from "@/components/sim/mainsim/utils/stackUtils";
@@ -83,17 +83,17 @@ export function SelectedModelEditModal() {
               [type === ActionType.FURNITURE_SCALE
                 ? "scale"
                 : type === ActionType.FURNITURE_ROTATE
-                  ? "rotation"
-                  : "position"]:
+                ? "rotation"
+                : "position"]:
                 type === ActionType.FURNITURE_SCALE
                   ? { x: currentValue, y: currentValue, z: currentValue }
                   : type === ActionType.FURNITURE_ROTATE
-                    ? {
+                  ? {
                       x: currentValue[0],
                       y: currentValue[1],
                       z: currentValue[2],
                     }
-                    : {
+                  : {
                       x: currentValue[0],
                       y: currentValue[1],
                       z: currentValue[2],
@@ -102,17 +102,17 @@ export function SelectedModelEditModal() {
                 [type === ActionType.FURNITURE_SCALE
                   ? "scale"
                   : type === ActionType.FURNITURE_ROTATE
-                    ? "rotation"
-                    : "position"]:
+                  ? "rotation"
+                  : "position"]:
                   type === ActionType.FURNITURE_SCALE
                     ? { x: initialValue, y: initialValue, z: initialValue }
                     : type === ActionType.FURNITURE_ROTATE
-                      ? {
+                    ? {
                         x: initialValue[0],
                         y: initialValue[1],
                         z: initialValue[2],
                       }
-                      : {
+                    : {
                         x: initialValue[0],
                         y: initialValue[1],
                         z: initialValue[2],
@@ -150,28 +150,28 @@ export function SelectedModelEditModal() {
             [type === ActionType.FURNITURE_SCALE
               ? "scale"
               : type === ActionType.FURNITURE_ROTATE
-                ? "rotation"
-                : "position"]:
+              ? "rotation"
+              : "position"]:
               type === ActionType.FURNITURE_SCALE
                 ? { x: finalValue, y: finalValue, z: finalValue }
                 : type === ActionType.FURNITURE_ROTATE
-                  ? { x: finalValue[0], y: finalValue[1], z: finalValue[2] }
-                  : { x: finalValue[0], y: finalValue[1], z: finalValue[2] },
+                ? { x: finalValue[0], y: finalValue[1], z: finalValue[2] }
+                : { x: finalValue[0], y: finalValue[1], z: finalValue[2] },
             previousData: {
               [type === ActionType.FURNITURE_SCALE
                 ? "scale"
                 : type === ActionType.FURNITURE_ROTATE
-                  ? "rotation"
-                  : "position"]:
+                ? "rotation"
+                : "position"]:
                 type === ActionType.FURNITURE_SCALE
                   ? { x: initialValue, y: initialValue, z: initialValue }
                   : type === ActionType.FURNITURE_ROTATE
-                    ? {
+                  ? {
                       x: initialValue[0],
                       y: initialValue[1],
                       z: initialValue[2],
                     }
-                    : {
+                  : {
                       x: initialValue[0],
                       y: initialValue[1],
                       z: initialValue[2],
@@ -275,7 +275,8 @@ export function SelectedModelEditModal() {
       >
         <div className="flex flex-col gap-2 overflow-auto p-4 select-none">
           {loadedModels.map((model) => (
-            <button className="w-full bg-gray-50 border-gray-300 hover:bg-green-50 hover:border-green-300 active:bg-gradient-to-r active:from-green-500 active:to-green-600 active:text-white border-2 rounded-lg p-3 text-left text-ellipsis overflow-hidden whitespace-nowrap cursor-pointer transition-all duration-200"
+            <button
+              className="w-full bg-gray-50 border-gray-300 hover:bg-green-50 hover:border-green-300 active:bg-gradient-to-r active:from-green-500 active:to-green-600 active:text-white border-2 rounded-lg p-3 text-left text-ellipsis overflow-hidden whitespace-nowrap cursor-pointer transition-all duration-200"
               key={model.id}
               onClick={() => {
                 selectModel(model.id);
@@ -308,26 +309,17 @@ export function SelectedModelEditModal() {
           {/* 크기 조정 */}
           <div className="mb-4 font-bold ">
             <ControlSlider
-              label={`W ${Math.ceil(
-                selectedModel.length[0] *
-                (Array.isArray(selectedModel.scale)
+              label={(() => {
+                const scale = Array.isArray(selectedModel.scale)
                   ? selectedModel.scale[0]
-                  : selectedModel.scale)
+                  : selectedModel.scale;
 
-              )} × H${Math.ceil(
-
-                selectedModel.length[1] *
-                (Array.isArray(selectedModel.scale)
-                  ? selectedModel.scale[1]
-                  : selectedModel.scale)
-
-              )} × D${Math.ceil(
-                selectedModel.length[2] *
-                (Array.isArray(selectedModel.scale)
-                  ? selectedModel.scale[2]
-                  : selectedModel.scale)
-              )}`}
-
+                return `W${Math.ceil(
+                  selectedModel.length[0] * scale
+                )} × H${Math.ceil(
+                  selectedModel.length[1] * scale
+                )} × D${Math.ceil(selectedModel.length[2] * scale)}`;
+              })()}
               value={
                 Array.isArray(selectedModel.scale)
                   ? selectedModel.scale[0]
@@ -343,9 +335,10 @@ export function SelectedModelEditModal() {
                   ActionType.FURNITURE_SCALE,
                   initialValue,
                   finalValue,
-                  `가구 "${selectedModel.name ||
-                  selectedModel.furnitureName ||
-                  "Unknown"
+                  `가구 "${
+                    selectedModel.name ||
+                    selectedModel.furnitureName ||
+                    "Unknown"
                   }"의 크기를 변경했습니다`
                 );
               }}
@@ -377,9 +370,10 @@ export function SelectedModelEditModal() {
                   ActionType.FURNITURE_MOVE,
                   initialPosition,
                   finalPosition,
-                  `가구 "${selectedModel.name ||
-                  selectedModel.furnitureName ||
-                  "Unknown"
+                  `가구 "${
+                    selectedModel.name ||
+                    selectedModel.furnitureName ||
+                    "Unknown"
                   }"의 높이를 변경했습니다`
                 );
               }}
@@ -417,10 +411,12 @@ export function SelectedModelEditModal() {
                     ActionType.FURNITURE_ROTATE,
                     initialRotation,
                     newRotation,
-                    `가구 "${selectedModel.name ||
-                    selectedModel.furnitureName ||
-                    "Unknown"
-                    }"의 ${axis}축을 ${degrees > 0 ? "+" : ""
+                    `가구 "${
+                      selectedModel.name ||
+                      selectedModel.furnitureName ||
+                      "Unknown"
+                    }"의 ${axis}축을 ${
+                      degrees > 0 ? "+" : ""
                     }${degrees}° 회전했습니다`
                   );
                 }}
@@ -437,9 +433,10 @@ export function SelectedModelEditModal() {
                     ActionType.FURNITURE_ROTATE,
                     initialRotation,
                     finalRotation,
-                    `가구 "${selectedModel.name ||
-                    selectedModel.furnitureName ||
-                    "Unknown"
+                    `가구 "${
+                      selectedModel.name ||
+                      selectedModel.furnitureName ||
+                      "Unknown"
                     }"의 ${axis}축을 회전했습니다`
                   );
                 }}
@@ -453,7 +450,6 @@ export function SelectedModelEditModal() {
             <button
               onClick={handleStartStackingMode}
               className="tool-btn tool-btn-green-active flex-1"
-
             >
               쌓기
             </button>
@@ -483,10 +479,11 @@ export function SelectedModelEditModal() {
                       object_id: selectedModel.object_id,
                     },
                   },
-                  description: `가구 "${selectedModel.name ||
+                  description: `가구 "${
+                    selectedModel.name ||
                     selectedModel.furnitureName ||
                     "Unknown"
-                    }"를 삭제했습니다`,
+                  }"를 삭제했습니다`,
                 });
 
                 // 실제 가구 삭제
@@ -494,7 +491,6 @@ export function SelectedModelEditModal() {
                 deselectModel();
               }}
               className="tool-btn tool-btn-red-active flex-1"
-
             >
               삭제
             </button>

--- a/next/components/sim/preview/PreviewManager.tsx
+++ b/next/components/sim/preview/PreviewManager.tsx
@@ -29,12 +29,33 @@ function GLBPreview({
       const modelSize = new THREE.Vector3();
       box.getSize(modelSize);
 
-      // 목표 크기로 스케일 조정
-      const targetScale = scale.map(
-        (target, i) => target / modelSize.getComponent(i)
-      );
+      // GLTF 실제 크기와 length 배열 매핑하여 스케일 조정
+      const actualW = modelSize.x,
+        actualD = modelSize.z;
+      const lengthW = scale[0] / 0.001, // scale에서 역산하여 length 값 구하기
+        lengthD = scale[2] / 0.001;
+
+      // 큰 것끼리, 작은 것끼리 매핑
+      const [mappedX, mappedZ] =
+        actualW >= actualD
+          ? [Math.max(lengthW, lengthD), Math.min(lengthW, lengthD)]
+          : [Math.min(lengthW, lengthD), Math.max(lengthW, lengthD)];
+
+      // 회전 조건: width와 depth가 뒤바뀐 경우
+      const needsRotation = (lengthW > lengthD && actualW < actualD) || (lengthW < lengthD && actualW > actualD);
+
+      const targetScale = [
+        (mappedX * 0.001) / actualW,
+        scale[1] / modelSize.y,
+        (mappedZ * 0.001) / actualD,
+      ];
 
       meshRef.current.scale.set(targetScale[0], targetScale[1], targetScale[2]);
+
+      // 필요시 90도 회전
+      if (needsRotation) {
+        meshRef.current.rotation.y = Math.PI / 2;
+      }
 
       // 바닥 위치 조정
       const min = box.min;

--- a/next/components/sim/slices/modelSlice.js
+++ b/next/components/sim/slices/modelSlice.js
@@ -249,4 +249,5 @@ export const modelSlice = (set, get) => ({
       newMap.delete(modelId);
       return { modelBoundingBoxFunctions: newMap };
     }),
+
 });


### PR DESCRIPTION
일부 가구에서 의도한 width/depth 비율과 실제 생성된 3D 모델의 비율이 일치하지 않은 경우가 있었습니다

아래 가구는 놀랍게도 침대인데, 실제 침대의 긴 쪽이 짧게 표현되고 짧은 쪽이 길게 모델이 만들어졌습니다

<img width="173" height="252" alt="image" src="https://github.com/user-attachments/assets/11128ed9-f904-48eb-903a-90b94612009d" />

저희 DB의 width / depth 비율과 GLB 모델의 width / depth 비율이 동일하지 않은 경우, DB 기준으로 생성되는 모델의 회전 및 규격이 자동 보정돼게끔 코드 수정했습니다

<img width="325" height="365" alt="image" src="https://github.com/user-attachments/assets/077c1cb2-6a67-4d57-aea6-b1127a0a202c" />
