### PR TITLE
fix: docker-compose file fixed 빌드 실패하여

### DIFF
--- a/docker-compose.next.yml
+++ b/docker-compose.next.yml
@@ -7,8 +7,6 @@ services:
     ports:
       - "6379:6379"
     restart: unless-stopped
-    volumes:
-      - redis_data:/data
   next:
     image: ${ECR_REGISTRY}/${ECR_REPO_NEXT}:${IMAGE_TAG}
     ports:

--- a/docker-compose.socket.yml
+++ b/docker-compose.socket.yml
@@ -6,8 +6,6 @@ services:
     ports:
       - "6379:6379"
     restart: unless-stopped
-    volumes:
-      - redis_data:/data
   socket:
     image: ${ECR_REGISTRY}/${ECR_REPO_SOCKET}:${IMAGE_TAG}
     ports:


### PR DESCRIPTION
err: time="2025-09-18T12:22:07Z" level=warning msg="***/next/docker-compose.next.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
err: service "redis" refers to undefined volume redis_data: invalid compose project

```yaml
volumes:
      - redis_data:/data
```

볼륨 제거 후 리빌드