### PR TITLE
hotfix: docker-compose socket redis-server existed error

### DIFF
--- a/docker-compose.socket.yml
+++ b/docker-compose.socket.yml
@@ -1,11 +1,6 @@
 version: '3.8'
 
 services:
-  redis:
-    image: redis:alpine
-    ports:
-      - "6379:6379"
-    restart: unless-stopped
   socket:
     image: ${ECR_REGISTRY}/${ECR_REPO_SOCKET}:${IMAGE_TAG}
     ports:


### PR DESCRIPTION
out: Login Succeeded
err: https://docs.docker.com/engine/reference/commandline/login/#credential-stores
err: time="2025-09-18T12:37:36Z" level=warning msg="***/socket/docker-compose.socket.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
err:  socket Pulling 
err:  redis Pulling 
err:  9824c27679d3 Already exists 
err:  6a088b2daae0 Already exists 
err:  52719e552fdf Already exists 
err:  016c0e952111 Already exists 

### Actions에서 Error 확인