### PR TITLE
fix : 질감 버그 수정

### DIFF
--- a/next/cache-medata.json
+++ b/next/cache-medata.json
@@ -65,9 +65,27 @@
       "accessCount": 3,
       "fileSize": 84860,
       "createdAt": "2025. 9. 18. 오후 7:01:38"
+    },
+    "75c624ef-4e85-48a7-995b-9e8c018441e1.glb": {
+      "lastAccessed": "2025. 9. 19. 오후 4:43:35",
+      "accessCount": 1,
+      "fileSize": 189856,
+      "createdAt": "2025. 9. 19. 오후 4:43:35"
+    },
+    "fa2894a2-a591-411b-b372-bc052e6960e2.glb": {
+      "lastAccessed": "2025. 9. 19. 오후 4:49:33",
+      "accessCount": 3,
+      "fileSize": 156272,
+      "createdAt": "2025. 9. 19. 오후 4:49:29"
+    },
+    "19bae8ea-8aad-477b-9e85-a28eb0da1983.glb": {
+      "lastAccessed": "2025. 9. 19. 오후 4:49:32",
+      "accessCount": 3,
+      "fileSize": 57748,
+      "createdAt": "2025. 9. 19. 오후 4:49:30"
     }
   },
-  "totalSize": 1064208,
+  "totalSize": 1468084,
   "maxSize": 52428800,
   "lastCleanup": "2025. 9. 18. 오후 12:42:14"
 }

--- a/next/components/sim/slices/environmentSlice.js
+++ b/next/components/sim/slices/environmentSlice.js
@@ -32,6 +32,10 @@ export const environmentSlice = (set, get) => ({
   floorColor: "#875f32",
   backgroundColor: "#87CEEB",
 
+  // 원본 질감 사용 여부
+  useOriginalTexture: false,
+  useOriginalWallTexture: false,
+
   ////////////////////////////////////
   // [09.15] 바닥재 텍스처 관련 상태
   // "color" | "vinyl" | "wood" | "tile"
@@ -153,4 +157,7 @@ export const environmentSlice = (set, get) => ({
       get().collaborationCallbacks.broadcastWallTextureChange?.(texture);
     }
   },
+
+  setUseOriginalTexture: (use) => set({ useOriginalTexture: use }),
+  setUseOriginalWallTexture: (use) => set({ useOriginalWallTexture: use }),
 });


### PR DESCRIPTION
완료한 작업 요약:

  1. 그림자 문제 해결

  - 문제: 바닥재가 타일/마루/대리석일 때 방위각/고도에 따른
  그림자가 보이지 않음
  - 원인: meshBasicMaterial 사용 (조명을 받지 않음)
  - 해결: 모든 Material을 meshStandardMaterial로 통일

  2. 바닥재 타입 변경 버그 수정

  - 문제: 바닥재 타입 버튼 클릭 시 적용되지 않음
  - 원인: 복잡한 isBlackColor 체크 로직과 Material 혼용
  - 해결:
    - isPureBlack 함수 및 복잡한 조건문 제거
    - Material에 key prop 추가하여 강제 리렌더링
    - 바닥재/벽지 모두 깔끔한 구조로 단순화

  3. 원본질감 기능 구현

  - 바닥재: 원본질감 on/off 토글 버튼 추가
  - 벽지: 바닥재와 동일한 원본질감 기능 추가
  - 기능:
    - 원본질감 ON: 순수 텍스처만 표시 (색상 설정 불가)
    - 원본질감 OFF: 색상+텍스처 혼합
    - 타입 변경 시 자동으로 원본질감 모드 해제

  4. 원본질감 밝기 문제 해결

  - 문제: 원본질감 모드에서 텍스처가 과도하게 밝게 표시
  - 원인: 강한 조명 설정으로 인한 과노출
  - 해결: color={0x808080} 적용하여 밝기 조절

  최종 결과: 바닥재와 벽지 모두에서 그림자가 정상 표시되고,      
  원본질감 기능으로 공용 텍스처의 자연스러운 색감을 볼 수        
  있게 되었습니다.