### PR TITLE
fix: 원본 질감 여부 저장 / 로드 / 웹소켓 지원

### DIFF
--- a/next/app/api/rooms/clone/route.ts
+++ b/next/app/api/rooms/clone/route.ts
@@ -106,6 +106,8 @@ export async function POST(req: NextRequest) {
           environment_preset: original_room?.environment_preset || "apartment",
           wall_type: original_room?.wall_type || "color",
           floor_type: original_room?.floor_type || "color",
+          floor_use_original_texture: original_room?.floor_use_original_texture || false,
+          wall_use_original_texture: original_room?.wall_use_original_texture || false,
         },
       });
 

--- a/next/app/api/sim/load/[room_id]/route.ts
+++ b/next/app/api/sim/load/[room_id]/route.ts
@@ -132,6 +132,8 @@ export async function GET(
           environment_preset: true,
           wall_type: true,
           floor_type: true,
+          floor_use_original_texture: true,
+          wall_use_original_texture: true,
         }
       }),
       prisma.room_objects.findMany({ 

--- a/next/app/api/sim/save/route.ts
+++ b/next/app/api/sim/save/route.ts
@@ -104,6 +104,8 @@ export async function POST(req: NextRequest) {
       environmentPreset,
       wallType,
       floorType,
+      floorUseOriginalTexture,
+      wallUseOriginalTexture,
     } = body;
 
     // 필수 파라미터 확인
@@ -179,6 +181,8 @@ export async function POST(req: NextRequest) {
             environment_preset: environmentPreset,
             wall_type: wallType || "color",
             floor_type: floorType || "color",
+            floor_use_original_texture: floorUseOriginalTexture || false,
+            wall_use_original_texture: wallUseOriginalTexture || false,
           },
         });
       } catch (roomUpdateError) {

--- a/next/components/sim/collaboration/useCollaboration.js
+++ b/next/components/sim/collaboration/useCollaboration.js
@@ -43,6 +43,8 @@ export function useCollaboration(roomId) {
     setEnvironmentPreset,
     setWallTexture,
     setFloorTexture,
+    setUseOriginalTexture,
+    setUseOriginalWallTexture,
   } = useStore();
 
   const router = useRouter();
@@ -300,6 +302,18 @@ export function useCollaboration(roomId) {
       }
     });
 
+    socket.current.on("use-original-texture-changed", (data) => {
+      if (data.userId !== currentUser.id) {
+        setUseOriginalTexture(data.use, false);
+      }
+    });
+
+    socket.current.on("use-original-wall-texture-changed", (data) => {
+      if (data.userId !== currentUser.id) {
+        setUseOriginalWallTexture(data.use, false);
+      }
+    });
+
     socket.current.on("wall-added", (data) => {
       if (data.userId !== currentUser.id) {
         console.log("wall-added 데이터 수신:", data);
@@ -405,6 +419,8 @@ export function useCollaboration(roomId) {
         broadcastEnvironmentPresetChange,
         broadcastWallTextureChange,
         broadcastFloorTextureChange,
+        broadcastUseOriginalTextureChange,
+        broadcastUseOriginalWallTextureChange,
       });
     } else {
       setCollaborationCallbacks({
@@ -425,6 +441,8 @@ export function useCollaboration(roomId) {
         broadcastEnvironmentPresetChange: null,
         broadcastWallTextureChange: null,
         broadcastFloorTextureChange: null,
+        broadcastUseOriginalTextureChange: null,
+        broadcastUseOriginalWallTextureChange: null,
       });
     }
   }, [collaborationMode]);
@@ -550,6 +568,20 @@ export function useCollaboration(roomId) {
     });
   };
 
+  const broadcastUseOriginalTextureChange = (use) => {
+    emitEvent("use-original-texture-changed", {
+      userId: currentUser.id,
+      use,
+    });
+  };
+
+  const broadcastUseOriginalWallTextureChange = (use) => {
+    emitEvent("use-original-wall-texture-changed", {
+      userId: currentUser.id,
+      use,
+    });
+  };
+
   const broadcastWallAdd = (wallData) => {
     console.log("broadcast WallData", wallData);
     emitEvent("wall-added", {
@@ -594,6 +626,10 @@ export function useCollaboration(roomId) {
     broadcastFloorColorChange,
     broadcastBackgroundColorChange,
     broadcastEnvironmentPresetChange,
+    broadcastWallTextureChange,
+    broadcastFloorTextureChange,
+    broadcastUseOriginalTextureChange,
+    broadcastUseOriginalWallTextureChange,
 
     // 연결 관리
     disconnect,

--- a/next/components/sim/slices/collaborationSlice.js
+++ b/next/components/sim/slices/collaborationSlice.js
@@ -30,6 +30,8 @@ export const collaborationSlice = (set, get) => ({
     broadcastEnvironmentPresetChange: null,
     broadcastWallTextureChange: null,
     broadcastFloorTextureChange: null,
+    broadcastUseOriginalTextureChange: null,
+    broadcastUseOriginalWallTextureChange: null,
   },
 
   // 쓰로틀링 관리 객체

--- a/next/components/sim/slices/environmentSlice.js
+++ b/next/components/sim/slices/environmentSlice.js
@@ -158,6 +158,16 @@ export const environmentSlice = (set, get) => ({
     }
   },
 
-  setUseOriginalTexture: (use) => set({ useOriginalTexture: use }),
-  setUseOriginalWallTexture: (use) => set({ useOriginalWallTexture: use }),
+  setUseOriginalTexture: (use, shouldBroadcast = true) => {
+    set({ useOriginalTexture: use });
+    if (shouldBroadcast) {
+      get().collaborationCallbacks.broadcastUseOriginalTextureChange?.(use);
+    }
+  },
+  setUseOriginalWallTexture: (use, shouldBroadcast = true) => {
+    set({ useOriginalWallTexture: use });
+    if (shouldBroadcast) {
+      get().collaborationCallbacks.broadcastUseOriginalWallTextureChange?.(use);
+    }
+  },
 });

--- a/next/components/sim/slices/roomSlice.js
+++ b/next/components/sim/slices/roomSlice.js
@@ -188,6 +188,8 @@ export const roomSlice = (set, get) => ({
           environmentPreset: currentState.environmentPreset,
           wallType: currentState.wallTexture,
           floorType: currentState.floorTexture,
+          floorUseOriginalTexture: currentState.useOriginalTexture,
+          wallUseOriginalTexture: currentState.useOriginalWallTexture,
         }),
       });
 
@@ -353,6 +355,8 @@ export const roomSlice = (set, get) => ({
           environmentPreset: currentState.environmentPreset,
           wallType: currentState.wallTexture,
           floorType: currentState.floorTexture,
+          floorUseOriginalTexture: currentState.useOriginalTexture,
+          wallUseOriginalTexture: currentState.useOriginalWallTexture,
         }),
       });
 
@@ -446,6 +450,8 @@ export const roomSlice = (set, get) => ({
       const floorColor = result.floor_color || "#875f32";
       const wallTexture = result.wall_type || "color";
       const floorTexture = result.floor_type || "color";
+      const useOriginalTexture = result.floor_use_original_texture || false;
+      const useOriginalWallTexture = result.wall_use_original_texture || false;
 
       // wallUtils를 사용하여 방 중앙과 카메라 초기 위치 계산
       let roomCenter = [0, 0, 0];
@@ -470,6 +476,8 @@ export const roomSlice = (set, get) => ({
         floorColor: floorColor,
         wallTexture: wallTexture,
         floorTexture: floorTexture,
+        useOriginalTexture: useOriginalTexture,
+        useOriginalWallTexture: useOriginalWallTexture,
         backgroundColor: result.background_color || "#87CEEB",
         environmentPreset: result.environment_preset || "apartment",
         roomCenter: roomCenter,

--- a/next/lib/services/simulator/extractRoomInfo.ts
+++ b/next/lib/services/simulator/extractRoomInfo.ts
@@ -17,6 +17,8 @@ export const extractRoomInfo = async (
   const environment_preset = room.environment_preset || "apartment";
   const wall_type = room.wall_type || "color";
   const floor_type = room.floor_type || "color";
+  const floor_use_original_texture = room.floor_use_original_texture || false;
+  const wall_use_original_texture = room.wall_use_original_texture || false;
   const result: SimualtorModel = {
     success: true,
     room_id: room_id,
@@ -36,6 +38,8 @@ export const extractRoomInfo = async (
     environment_preset: environment_preset,
     wall_type: wall_type,
     floor_type: floor_type,
+    floor_use_original_texture: floor_use_original_texture,
+    wall_use_original_texture: wall_use_original_texture,
   };
 
   return result;

--- a/next/lib/textures/addColorToTexture.ts
+++ b/next/lib/textures/addColorToTexture.ts
@@ -1,0 +1,52 @@
+import sharp from "sharp";
+
+/**
+ * 이미지 버퍼와 색상을 합성하는 함수
+ * @param imageBuffer - 업로드된 이미지 버퍼
+ * @param color - 섞을 색상 (#rrggbb)
+ * @param alpha - 색상 투명도 (0~1, 기본 0.5)
+ * @returns Promise<Buffer> - 합성된 이미지 버퍼 (PNG)
+ */
+export async function mixImageWithColorServer(
+  imageBuffer: Buffer,
+  color: string,
+  alpha: number = 0.5
+): Promise<Buffer> {
+  // sharp로 이미지 불러오기
+  const image = sharp(imageBuffer);
+  const { width, height } = await image.metadata();
+
+  if (!width || !height) throw new Error("Invalid image dimensions");
+
+  // RGBA 값으로 변환
+  const { r, g, b } = hexToRgb(color);
+
+  // 색상 레이어 생성
+  const colorLayer = {
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r, g, b, alpha },
+    },
+  };
+
+  // 이미지 합성
+  const outputBuffer = await sharp(colorLayer)
+    .composite([{ input: await image.png().toBuffer(), blend: "over" }])
+    .png()
+    .toBuffer();
+
+  return outputBuffer;
+}
+
+/** 헥스 색상 (#rrggbb) → r,g,b 객체 */
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const match = hex.replace("#", "").match(/.{2}/g);
+  if (!match) throw new Error("Invalid hex color");
+  return {
+    r: parseInt(match[0], 16),
+    g: parseInt(match[1], 16),
+    b: parseInt(match[2], 16),
+  };
+}

--- a/next/prisma/schema.prisma
+++ b/next/prisma/schema.prisma
@@ -164,32 +164,34 @@ model room_walls {
 }
 
 model rooms {
-  room_id             String          @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  user_id             String
-  title               String          @db.VarChar(100)
-  description         String?
-  thumbnail_url       String?
-  is_public           Boolean?        @default(true)
-  view_count          Int?            @default(0)
-  created_at          DateTime?       @default(now()) @db.Timestamp(6)
-  updated_at          DateTime?       @default(now()) @db.Timestamp(6)
-  root_room_id        String?         @db.Uuid
-  collab_on           Boolean?        @default(false)
-  wall_color          String          @default("#969593")
-  floor_color         String          @default("#875F32")
-  background_color    String          @default("#87CEEB")
-  environment_preset  String          @default("apartment")
-  collab_chat_room_id String?         @db.Uuid
-  wall_type           String?         @default("color")
-  floor_type          String?         @default("color")
-  room_comments       room_comments[]
-  room_likes          room_likes[]
-  room_objects        room_objects[]
-  room_walls          room_walls[]
-  chat_rooms          chat_rooms?     @relation(fields: [collab_chat_room_id], references: [chat_room_id], onUpdate: NoAction, map: "fk_rooms_collab_chat_room")
-  rooms               rooms?          @relation("roomsTorooms", fields: [root_room_id], references: [room_id], onUpdate: NoAction, map: "fk_rooms_root_room")
-  other_rooms         rooms[]         @relation("roomsTorooms")
-  user                User            @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  room_id                    String          @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  user_id                    String
+  title                      String          @db.VarChar(100)
+  description                String?
+  thumbnail_url              String?
+  is_public                  Boolean?        @default(true)
+  view_count                 Int?            @default(0)
+  created_at                 DateTime?       @default(now()) @db.Timestamp(6)
+  updated_at                 DateTime?       @default(now()) @db.Timestamp(6)
+  root_room_id               String?         @db.Uuid
+  collab_on                  Boolean?        @default(false)
+  wall_color                 String          @default("#969593")
+  floor_color                String          @default("#875F32")
+  background_color           String          @default("#87CEEB")
+  environment_preset         String          @default("apartment")
+  collab_chat_room_id        String?         @db.Uuid
+  wall_type                  String?         @default("color")
+  floor_type                 String?         @default("color")
+  wall_use_original_texture  Boolean         @default(false)
+  floor_use_original_texture Boolean         @default(false)
+  room_comments              room_comments[]
+  room_likes                 room_likes[]
+  room_objects               room_objects[]
+  room_walls                 room_walls[]
+  chat_rooms                 chat_rooms?     @relation(fields: [collab_chat_room_id], references: [chat_room_id], onUpdate: NoAction, map: "fk_rooms_collab_chat_room")
+  rooms                      rooms?          @relation("roomsTorooms", fields: [root_room_id], references: [room_id], onUpdate: NoAction, map: "fk_rooms_root_room")
+  other_rooms                rooms[]         @relation("roomsTorooms")
+  user                       User            @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([is_public], map: "idx_rooms_public")
   @@index([user_id], map: "idx_rooms_user")

--- a/socket/src/collab/collab.gateway.ts
+++ b/socket/src/collab/collab.gateway.ts
@@ -803,6 +803,52 @@ export class CollabGateway {
     });
   }
 
+  // 원본 텍스처 사용 변경
+  @SubscribeMessage('use-original-texture-changed')
+  async onUseOriginalTextureChanged(
+    @MessageBody() data: { userId: string; use: boolean },
+    @ConnectedSocket() socket: Socket,
+  ) {
+    this.logger.log(`🖼️ USE ORIGINAL TEXTURE CHANGED: ${data.use} by ${data.userId}`);
+
+    // 사용자 활동 시간 업데이트
+    const roomId = Array.from(socket.rooms).find((room) => room !== socket.id);
+    if (roomId) {
+      await this.redisService.updateRoomUser(roomId, data.userId, {
+        lastActivity: Date.now(),
+      });
+    }
+
+    socket.rooms.forEach((room) => {
+      if (room !== socket.id) {
+        socket.to(room).emit('use-original-texture-changed', data);
+      }
+    });
+  }
+
+  // 원본 벽 텍스처 사용 변경
+  @SubscribeMessage('use-original-wall-texture-changed')
+  async onUseOriginalWallTextureChanged(
+    @MessageBody() data: { userId: string; use: boolean },
+    @ConnectedSocket() socket: Socket,
+  ) {
+    this.logger.log(`🧱 USE ORIGINAL WALL TEXTURE CHANGED: ${data.use} by ${data.userId}`);
+
+    // 사용자 활동 시간 업데이트
+    const roomId = Array.from(socket.rooms).find((room) => room !== socket.id);
+    if (roomId) {
+      await this.redisService.updateRoomUser(roomId, data.userId, {
+        lastActivity: Date.now(),
+      });
+    }
+
+    socket.rooms.forEach((room) => {
+      if (room !== socket.id) {
+        socket.to(room).emit('use-original-wall-texture-changed', data);
+      }
+    });
+  }
+
   // 미활동 사용자 연결해제
   // @Cron('0 */5 * * * *') // 5분에 1번씩 실행
   // async cleanupInactiveUsers() {


### PR DESCRIPTION
종호형이 버그 잡은 질감+색상 -> 이제 원본 질감을 토글로 조절합니다
따라서 이를 DB에서 저장되게끔 구현. 웹소켓도 구현

`npx prisma generate` 필수.