### PR TITLE
fix : 가구 카테고리 오류 수정

### DIFF
--- a/next/cache-medata.json
+++ b/next/cache-medata.json
@@ -83,9 +83,15 @@
       "accessCount": 3,
       "fileSize": 57748,
       "createdAt": "2025. 9. 19. 오후 4:49:30"
+    },
+    "580331c1-dbd4-433c-80b5-63b32fdca347.glb": {
+      "lastAccessed": "2025. 9. 22. 오후 7:20:10",
+      "accessCount": 3,
+      "fileSize": 65632,
+      "createdAt": "2025. 9. 22. 오후 7:19:33"
     }
   },
-  "totalSize": 1468084,
+  "totalSize": 1533716,
   "maxSize": 52428800,
   "lastCleanup": "2025. 9. 18. 오후 12:42:14"
 }

--- a/next/components/sim/SimSideView.tsx
+++ b/next/components/sim/SimSideView.tsx
@@ -1,6 +1,6 @@
 "use client"; // 클라이언트 컴포넌트라는 것을 명시 // 이거 안하면 렌더링 안됨
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import SideTitle from "@/components/sim/side/SideTitle";
 import SideSearch from "@/components/sim/side/SideSearch";
 import SideCategories from "@/components/sim/side/SideCategories";
@@ -9,6 +9,7 @@ import SideItems from "@/components/sim/side/SideItems";
 import { HistoryControls, useHistoryKeyboard } from "@/components/sim/history";
 import type { furnitures as Furniture } from "@prisma/client";
 import { RoomInfo } from "@/lib/services/roomService";
+import { useStore } from "./useStore";
 
 
 const SideViewContent: React.FC<{
@@ -31,9 +32,18 @@ const SideViewContent: React.FC<{
   const [error, setError] = useState<string | null>(null);
   const itemsPerPage = 8;
 
+  const { setSelectedCategory: setStoreCategory } = useStore();
+
+  // 컴포넌트 마운트 시 카테고리를 전체(99)로 초기화
+  useEffect(() => {
+    setStoreCategory(99);
+  }, [roomId, setStoreCategory]);
+
   useHistoryKeyboard();
 
   const handleCategorySelect = (category: string) => {
+    if (selectedCategory === category) return; // 같은 카테고리면 무시
+
     setSearchResults([]);
     setSelectedCategory(category);
     setSearchQuery("");


### PR DESCRIPTION
1. 같은 가구 카테고리 두번 클릭시 아무것도 안나오는 문제
- 같은 카테고리를 재선택할 때는 아무것도 하지 않도록 수정:
```javascript
 if (selectedCategory === category) return; // 같은 카테고리면 무시
```

2. 시뮬레이터로 다시 돌아올때, `전체` 가구 카테고리가 아닌 이전에 조작했던 카테고리로 남아있는 문제 
```javascript
// 컴포넌트 마운트 시 카테고리를 전체(99)로 초기화
  useEffect(() => {
    setStoreCategory(99);
  }, [roomId, setStoreCategory]);
```