### PR TITLE
fix : 벽 높이 하드코딩 수정

### DIFF
--- a/next/components/sim/SimulatorCore.tsx
+++ b/next/components/sim/SimulatorCore.tsx
@@ -263,7 +263,7 @@ function Floor({ wallsData }: { wallsData: any[] }) {
   // 벽 데이터가 없으면 기본 바닥 렌더링
   if (!wallsData || wallsData.length === 0) {
     return (
-      <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <mesh position={[0, 0, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
         <planeGeometry args={[20, 20]} />
         <FloorMaterial />
       </mesh>
@@ -308,7 +308,7 @@ function Floor({ wallsData }: { wallsData: any[] }) {
 
   return (
     <mesh
-      position={[centerX, -0.01, centerZ]}
+      position={[centerX, 0, centerZ]}
       rotation={[-Math.PI / 2, 0, 0]}
       receiveShadow
     >

--- a/next/components/sim/mainsim/wall/MergedWalls.jsx
+++ b/next/components/sim/mainsim/wall/MergedWalls.jsx
@@ -44,8 +44,8 @@ export function MergedWalls({ wallsData }) {
         <Wall
           key={mergedWall.id}
           width={Math.max(mergedWall.dimensions.width, 0.5)}
-          height={2.5}
-          depth={0.15}
+          height={mergedWall.dimensions.height || 2.5}
+          depth={mergedWall.dimensions.depth || 0.15}
           position={mergedWall.position}
           rotation={mergedWall.rotation}
           id={mergedWall.id}
@@ -59,8 +59,8 @@ export function MergedWalls({ wallsData }) {
         <Wall
           key={wall.id}
           width={Math.max(wall.dimensions.width, 0.5)}
-          height={2.5}
-          depth={0.15}
+          height={wall.dimensions.height || 2.5}
+          depth={wall.dimensions.depth || 0.15}
           position={wall.position}
           rotation={wall.rotation}
           id={wall.id}

--- a/next/components/sim/slices/wallSlice.js
+++ b/next/components/sim/slices/wallSlice.js
@@ -177,11 +177,14 @@ export const wallSlice = (set, get) => ({
       // Y축 회전각 계산
       const rotationY = Math.atan2(-dz, dx);
 
+      // 벽 높이 결정 (기존 벽이 있으면 그 높이, 없으면 기본 5.0)
+      const wallHeight = state.wallsData[0]?.dimensions?.height || 5.0;
+
       const newWall = {
         id: id || `wall-${crypto.randomUUID()}`,
         position: [
           (snappedStart[0] + snappedEnd[0]) / 2, // 중점 X
-          state.wallsData[0]?.position[1] || 2.5, // 기존 벽 높이나 기본값
+          wallHeight / 2, // 벽 중심이 바닥(Y=0)에서 높이/2 위치에 오도록
           (snappedStart[2] + snappedEnd[2]) / 2, // 중점 Z
         ],
         rotation: [
@@ -191,7 +194,7 @@ export const wallSlice = (set, get) => ({
         ],
         dimensions: {
           width: wallLength, // 계산된 길이 사용
-          height: 2.5, // 기존 벽 높이 사용
+          height: wallHeight, // 계산된 높이 사용
           depth: 0.15,
         },
       };


### PR DESCRIPTION
- 기본 벽들은 높이 5로 position Y=2.5에서 바닥(Y=0)에 닿음

- `MergedWallls` 에서 새로 추가한 벽들은 높이 2.5로 생성되어 (Y=2.5) 에서
바닥에서 1.25만큼 떠있음

- MergedWalls에서 높이를 2.5로 하드코딩했기 때문에 발생하는
문제 
->  동적으로 높이를 적용하도록 수정