### PR TITLE
fix: trellis model 생성 실패 시 throw error를 안전하게 return success: false로 수정

### DIFF
--- a/next/lib/trellis_api.js
+++ b/next/lib/trellis_api.js
@@ -172,7 +172,11 @@ export async function generateTrellisModel(furnitureId, imageUrl) {
         };
     } catch (error) {
         console.error('Trellis 모델 생성 실패:', error);
-        throw error;
+        return {
+            success: false,
+            model_url: null,
+            furniture_id: furnitureId
+        }
     }
 }
 


### PR DESCRIPTION
```javascript
catch (error) {
      console.error('Trellis 모델 생성 실패:', error);
      return {
          success: false,
          model_url: null,
          furniture_id: furnitureId
      }
  }
```

기존 코드는
```javascript
throw error;
```
를 던지는 코드에서 변경